### PR TITLE
Changed statsmodels >= 0.10.0, scipy >= 1.3.0. Fixes #112

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,16 +3,8 @@ from setuptools import setup
 setup(name='pbjam',
       packages=['pbjam'],
       #url='TODO',
-      install_requires=['numpy', 'pandas', 'emcee', 'statsmodels==0.9.0',
-                        'lightkurve', 'astropy', 'scipy==1.2.1',
+      install_requires=['numpy', 'pandas', 'emcee', 'statsmodels>=0.10.0',
+                        'lightkurve', 'astropy', 'scipy>=1.3.0',
                         'psutil', 'corner', 'pymc3', 'matplotlib>=1.5.3'],
       include_package_data=True,
       )
-
-
-
-
-
-
-
-


### PR DESCRIPTION
PBJam works all good when these two modules are up to date now.

I've noted that while installing PBJam, if you already have a different version of these modules it will not install the updated version for you, at least on my laptop.

Not sure why!



