### PR TITLE
Fix bug in jar.py/format_col caused by incorrect order of arguments to arr_to_lk

### DIFF
--- a/pbjam/jar.py
+++ b/pbjam/jar.py
@@ -344,7 +344,7 @@ def format_col(vardf, col, key):
     elif col.ndim == 2:
         x = np.array(col[0, :], dtype=float)
         y = np.array(col[1, :], dtype=float)
-        vardf[key] = np.array([arr_to_lk(x, y, vardf['ID'][0])], key)
+        vardf[key] = np.array([arr_to_lk(x, y, vardf['ID'][0], key)])
 
     # If dim = 3, it's a list of arrays or tuples
     elif col.ndim == 3:


### PR DESCRIPTION
This excerpt

````Python
import numpy as np
import pbjam

timeseries = np.random.rand(2, 10000)
s = pbjam.session(timeseries=timeseries, ID=200093173, numax=(600.0, 10.0), dnu=(35.00, 2.00),
                  teff=(5360, 100), bp_rp=(0.9120, 0.16), make_plots=True)
````
fails with the error message
````
Traceback (most recent call last):
  File "test_pbjam.py", line 11, in <module>
    teff=(5360, 100), bp_rp=(0.9120, 0.16), make_plots=True)
  File "/home/wball/pypi/PBjam/pbjam/jar.py", line 599, in __init__
    format_col(vardf, timeseries, 'timeseries')
  File "/home/wball/pypi/PBjam/pbjam/jar.py", line 347, in format_col
    vardf[key] = np.array([arr_to_lk(x, y, vardf['ID'][0])], key)
TypeError: arr_to_lk() missing 1 required positional argument: 'typ'
````
because the close brackets in the offending line (`vardf[key]...`) seem to be in the wrong order.

This PR should fix it.