### PR TITLE
Fixed change of periodogram to pg in session and other minor change.

### DIFF
--- a/pbjam/session.py
+++ b/pbjam/session.py
@@ -633,7 +633,7 @@ class session():
 
         for i in range(len(vardf)):
             self.stars.append(star(ID=vardf.loc[i, 'ID'],
-                                   periodogram=vardf.loc[i, 'psd'],
+                                   pg=vardf.loc[i, 'psd'],
                                    numax=vardf.loc[i, ['numax', 'numax_err']].values,
                                    dnu=vardf.loc[i, ['dnu', 'dnu_err']].values,
                                    teff=vardf.loc[i, ['teff', 'teff_err']].values,

--- a/pbjam/star.py
+++ b/pbjam/star.py
@@ -93,7 +93,7 @@ class star(plotting):
         self.path = os.path.join(*[path, f'{self.ID}'])
 
         try:
-            os.mkdir(self.path)
+            os.makedirs(self.path)
         except OSError:
             if verbose:
                 warnings.warn(f'Path {self.path} already exists - I will try to overwrite ... ')


### PR DESCRIPTION
Session would not initialise because `peridogram` had been changed to `pg` in the `star.__init__()` but not when `star()` is called in `session`.  This is now fixed.

`os.mkdir()` changed to `os.makedirs()` in `star.make_output_dir()` because the latter allows the creation of sub-directories (without, it wouldn't let me store the `star` output in a new directory within the current working directory) - not a bug, but allows for more general use cases.