### PR TITLE
Setup.py pulls from requirements.txt and pbjam.__version__ works again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,6 @@ venv.bak/
 
 # Visual Studio Code
 .vscode/
+
+# MacOS DS_Store
+.DS_Store

--- a/pbjam/__init__.py
+++ b/pbjam/__init__.py
@@ -4,6 +4,7 @@
 import os
 PACKAGEDIR = os.path.abspath(os.path.dirname(__file__))
 
+from .version import __version__
 from .priors import kde
 from .session import session
 from .asy_peakbag import asymp_spec_model

--- a/pbjam/session.py
+++ b/pbjam/session.py
@@ -356,7 +356,7 @@ def format_col(vardf, col, key):
     elif col.ndim == 2:
         x = np.array(col[0, :], dtype=float)
         y = np.array(col[1, :], dtype=float)
-        vardf[key] = np.array([arr_to_lk(x, y, vardf['ID'][0], key)])
+        vardf[key] = [arr_to_lk(x, y, vardf['ID'][0], key)]
 
     # If dim = 3, it's a list of arrays or tuples
     elif col.ndim == 3:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,8 @@ statsmodels>=0.10.0
 matplotlib>=1.5.3
 pandas
 emcee==3.0rc2
-lightkurve==1.1.1
+lightkurve>=1.2.0
 astropy
 corner
 pymc3
-nbsphinx
+nbsphinxs

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,8 +5,7 @@ matplotlib>=1.5.3
 pandas
 emcee==3.0rc2
 lightkurve==1.2.0
-astropy
+astropy==3.2.1
 corner
 pymc3
 nbsphinx
-psutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,9 @@ statsmodels>=0.10.0
 matplotlib>=1.5.3
 pandas
 emcee==3.0rc2
-lightkurve>=1.2.0
+lightkurve==1.2.0
 astropy
 corner
 pymc3
-nbsphinxs
+nbsphinx
+psutil

--- a/setup.py
+++ b/setup.py
@@ -11,9 +11,7 @@ setuptools.setup(
     long_description=open("README.rst").read(),
     url="https://pbjam.readthedocs.io/",
     packages=['pbjam'],
-    install_requires=['numpy', 'pandas', 'emcee==3.0rc2', 'statsmodels>=0.10.0',
-                      'lightkurve>=1.1.1', 'astropy', 'scipy>=1.3.0',
-                      'psutil', 'corner', 'pymc3', 'matplotlib>=1.5.3'],
+    install_requires=open('requirements.txt', 'r').read().splitlines(),
     include_package_data=True,
     license="MIT",
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setuptools.setup(
     long_description=open("README.rst").read(),
     url="https://pbjam.readthedocs.io/",
     packages=['pbjam'],
-    install_requires=open('requirements.txt', 'r').read().splitlines(),
+    install_requires=open('requirements.txt').read().splitlines(),
     include_package_data=True,
     license="MIT",
     classifiers=[


### PR DESCRIPTION
In response to @nielsenmb's [comment](https://github.com/grd349/PBjam/issues/159#issuecomment-537895781) in Issue #159 I have added a line which reads `requirements.txt` into the `install_requires` argument of `setuptools.setup` within `setup.py`. I have tested this and made sure that it correctly imports the list.

I noticed the module `psutil` as a requirement in `setup.py` before making the change, but it was not in `requirements.txt`. I added it to `requirements.txt`, but if it is no longer needed for PBjam then it should be removed before the merge.

I also noticed why `pbjam.__version__` was not working anymore - the line importing it had been removed from `__init__.py` (presumably by mistake in a previous commit). I have added this line back in and now you can call the version.

Finally, I added `.DS_Store` to `.gitignore` as these files are MacOS-specific.