### PR TITLE
Quick update feature addition to PBjam setup.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,7 @@ statsmodels>=0.10.0
 matplotlib>=1.5.3
 pandas
 emcee==3.0rc2
-lightkurve==1.2.0
-astropy==3.2.1
+lightkurve>=1.2.0
+astropy>=3.2.1
 corner
 pymc3
-nbsphinx

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ setuptools.setup(
     url="https://pbjam.readthedocs.io/",
     packages=['pbjam'],
     install_requires=open('requirements.txt').read().splitlines(),
+    extras_require={'docs': ["nbsphinx"]},
     include_package_data=True,
     license="MIT",
     classifiers=[


### PR DESCRIPTION
The package `nbsphinx` was previously added to `requirements.txt` which is now read by `setup.py`. However, `nbsphinx` is only used for compiling the docs - not required by the bulk of PBjam - and it is a large package.

I suggest using the `extras_require` argument in `setup()` which allows for optional requirements to be added. In my branch, `nbsphinx` is removed from `requirements.txt` and put as an extra requirements labelled as `'docs'`. A similar thing is done in [Lightkurve](https://github.com/KeplerGO/lightkurve/blob/c9a89c22d2a7fc8ac93f89a8392a572ae15c78b3/setup.py#L26) to specify non-compulsory packages.

If, in future, someone wants to work on the docs and would like to install PBjam with the relevant packages (`nbsphinx` at the moment), they can now run

```
pip install pbjam[docs]
```

and it will automatically install `nbsphinx` along with the other dependencies.

Also, versions in `requirements.txt` have been changed to `>=` to allow future dependancy updates where appropriate. If a particular future dependency version breaks PBjam, it is good practice to follow the requirement with `,!=#` where `#` is the offending version number.