### PR TITLE
Add an index label to index column

### DIFF
--- a/pbjam/star.py
+++ b/pbjam/star.py
@@ -190,7 +190,7 @@ class star(plotting):
         # Store
         outpath = lambda x: os.path.join(*[self.path, x])
         self.asy_fit.summary.to_csv(outpath(f'asy_fit_summary_{self.ID}.csv'),
-                                    index=True)
+                                    index=True, index_label='name')
         self.asy_fit.modeID.to_csv(outpath(f'asy_fit_modeID_{self.ID}.csv'),
                                    index=False)
 
@@ -238,7 +238,8 @@ class star(plotting):
 
         # Store
         outpath = lambda x: os.path.join(*[self.path, x])
-        self.peakbag.summary.to_csv(outpath(f'peakbag_summary_{self.ID}.csv'))
+        self.peakbag.summary.to_csv(outpath(f'peakbag_summary_{self.ID}.csv'),
+                                    index_label='name')
 
         if store_chains:
             pass # TODO need to pickle the samples if requested.


### PR DESCRIPTION
As far as I can tell, the current summary outputs have columns for the labels of each row but those columns themselves don't have names. e.g. I get output like

````
,mean,sd,mc_error,hpd_2.5,hpd_97.5,n_eff,Rhat
l0__0,468.5793432271731,1.145410726896085,0.03040796525815398,466.3214757809798,470.71946764791375,1502.394330525594,0.9994737399203655
l0__1,506.2840533100378,1.2235554019976191,0.03969486841714697,504.14111963555183,508.58490405921924,848.4093878643756,0.9999080760285258
...
````
Note the empty entry at the start of the first row.

This is currently annoying for me because it means I can't load the data with `numpy.genfromtxt`. e.g. if I use

````Python
data = np.genfromtxt('peakbag_summary_blah.csv', names=True, dtype=None, encoding='utf-8', delimiter=',')
````
I get errors about the number of columns on every line. It also means that when reading with `pandas.read_csv` the default column name for the parameter names is `Unnamed: 0`.

You're welcome to point out that it doesn't entirely make sense to use something like `numpy.genfromtxt` to read data like this, in which case you can reject this PR and I'll accept that I can't put off using Pandas forever.