### PR TITLE
Exclude statsmodels v0.11.0 due to bandwidth bug.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy
 scipy>=1.3.0
-statsmodels>=0.10.0
+statsmodels>=0.10.0,!=0.11.0
 matplotlib>=1.5.3
 pandas
 emcee>=3.0


### PR DESCRIPTION
I discovered a small bug in statsmodels v0.11.0 [here](https://github.com/statsmodels/statsmodels/issues/6511) which causes a ValueError when specifying `bw_fac` in making the KDE in PBjam.

This PR excludes statsmodels v0.11.0 from `requirements.txt`.

I am fixing the issue in statsmodels so hopefully it will be fixed in the next update.

Let me know if there's anything else which may be useful in this PR.