### PR TITLE
Update peakbag.py

### DIFF
--- a/pbjam/peakbag.py
+++ b/pbjam/peakbag.py
@@ -335,7 +335,7 @@ class peakbag(plotting):
         # REMOVE THIS WHEN pymc3 v3.8 is a bit older
         try:
             rhatfunc = pm.diagnostics.gelman_rubin
-            warnings.warn('pymc3.diagnostics.gelman_rubin is depcrecated; upgrade pymc3 to v3.8 or newer.', warnings.DeprecationWarning)
+            warnings.warn('pymc3.diagnostics.gelman_rubin is depcrecated; upgrade pymc3 to v3.8 or newer.', DeprecationWarning)
         except:
             rhatfunc = pm.stats.rhat
         

--- a/pbjam/tests/test_asy_peakbag.py
+++ b/pbjam/tests/test_asy_peakbag.py
@@ -69,6 +69,9 @@
 #     stars['nsamples'] = 10
 #     return stars
 
+def dummy_test():
+    pass
+
 # def does_it_run(func, args):
 #     if args is None:
 #         func()

--- a/pbjam/tests/test_asy_peakbag.py
+++ b/pbjam/tests/test_asy_peakbag.py
@@ -69,8 +69,8 @@
 #     stars['nsamples'] = 10
 #     return stars
 
-def dummy_test():
-    pass
+def test():
+    import pbjam
 
 # def does_it_run(func, args):
 #     if args is None:


### PR DESCRIPTION
Fix for pymc3 3.7 and 3.8 using the gelman_rubin vs. rhat methods.

Apparently warnings does not have an attribute called DeprecationWarning.