### PR TITLE
Teff and bp_rp are now optional inputs

### DIFF
--- a/pbjam/session.py
+++ b/pbjam/session.py
@@ -718,6 +718,8 @@ class session():
         _lk_to_pg(vardf)
 
 
+       
+
         for i in range(len(vardf)):
             self.stars.append(star(ID=vardf.loc[i, 'ID'],
                                    pg=vardf.loc[i, 'psd'],
@@ -767,16 +769,16 @@ class session():
         self.pb_model_type = model_type
 
         for i, st in enumerate(self.stars):
-            try:
-                st(bw_fac=bw_fac, tune=tune, norders=norders, 
+#            try:
+            st(bw_fac=bw_fac, tune=tune, norders=norders, 
                    model_type=self.pb_model_type, make_plots=make_plots, 
                    store_chains=store_chains, nthreads=nthreads)
                 
-                self.stars[i] = None
+            self.stars[i] = None
             
             # Crude way to send error messages that occur in star up to Session 
             # without ending the session. Is there a better way?
-            except Exception as ex:
-                 message = "Star {0} produced an exception of type {1} occurred. Arguments:\n{2!r}".format(st.ID, type(ex).__name__, ex.args)
-                 print(message)
+#            except Exception as ex:
+#                 message = "Star {0} produced an exception of type {1} occurred. Arguments:\n{2!r}".format(st.ID, type(ex).__name__, ex.args)
+#                 print(message)
             

--- a/pbjam/session.py
+++ b/pbjam/session.py
@@ -769,16 +769,16 @@ class session():
         self.pb_model_type = model_type
 
         for i, st in enumerate(self.stars):
-#            try:
-            st(bw_fac=bw_fac, tune=tune, norders=norders, 
+            try:
+                st(bw_fac=bw_fac, tune=tune, norders=norders, 
                    model_type=self.pb_model_type, make_plots=make_plots, 
                    store_chains=store_chains, nthreads=nthreads)
                 
-            self.stars[i] = None
+                self.stars[i] = None
             
             # Crude way to send error messages that occur in star up to Session 
             # without ending the session. Is there a better way?
-#            except Exception as ex:
-#                 message = "Star {0} produced an exception of type {1} occurred. Arguments:\n{2!r}".format(st.ID, type(ex).__name__, ex.args)
-#                 print(message)
+            except Exception as ex:
+                 message = "Star {0} produced an exception of type {1} occurred. Arguments:\n{2!r}".format(st.ID, type(ex).__name__, ex.args)
+                 print(message)
             

--- a/pbjam/star.py
+++ b/pbjam/star.py
@@ -83,9 +83,9 @@ class star(plotting):
         self.ID = ID
         self.pg = pg.flatten()  # in case user supplies unormalized spectrum
 
-        print(teff)
-        print(bp_rp)
-
+        # Teff and Gbp-Grp provide a lot of the same information, so only one of
+        # them need to be provided to start with. If one is not provided, PBjam
+        # will assume a wide prior on it.
         tst = [None,None]
         if np.all(np.array(teff) == tst) and np.all(np.array(bp_rp) == tst):
             raise ValueError('Must provide either teff or bp_rp arguments when initializing the star class.')
@@ -98,10 +98,6 @@ class star(plotting):
         self.dnu = dnu
         self.teff = teff
         self.bp_rp = bp_rp
-
-        print(self.teff)
-        print(self.bp_rp)
-
 
         self.f = self.pg.frequency.value
         self.s = self.pg.power.value

--- a/pbjam/star.py
+++ b/pbjam/star.py
@@ -21,6 +21,7 @@ from .peakbag import peakbag
 from .jar import get_priorpath, to_log10
 from .plotting import plotting
 import pandas as pd
+import numpy as np
 
 class star(plotting):
     """ Class for each star to be peakbagged
@@ -76,16 +77,31 @@ class star(plotting):
 
     """
 
-    def __init__(self, ID, pg, numax, dnu, teff, bp_rp, path=None,
-                 prior_file=None):
+    def __init__(self, ID, pg, numax, dnu, teff=[None,None], bp_rp=[None,None], 
+                 path=None, prior_file=None):
 
         self.ID = ID
         self.pg = pg.flatten()  # in case user supplies unormalized spectrum
+
+        print(teff)
+        print(bp_rp)
+
+        tst = [None,None]
+        if np.all(np.array(teff) == tst) and np.all(np.array(bp_rp) == tst):
+            raise ValueError('Must provide either teff or bp_rp arguments when initializing the star class.')
+        elif np.all(np.array(teff) == tst):
+            teff = [4889, 1500]
+        elif np.all(np.array(bp_rp) == tst):
+            bp_rp = [1.2927, 0.5]
 
         self.numax = numax
         self.dnu = dnu
         self.teff = teff
         self.bp_rp = bp_rp
+
+        print(self.teff)
+        print(self.bp_rp)
+
 
         self.f = self.pg.frequency.value
         self.s = self.pg.power.value

--- a/pbjam/tests/test_star.py
+++ b/pbjam/tests/test_star.py
@@ -3,7 +3,7 @@ import lightkurve as lk
 import astropy.units as units
 import numpy as np
 import pbjam.tests.pbjam_tests as pbt
-import os
+import os, pytest
 from ..star import star
 
 
@@ -20,6 +20,15 @@ def test_star_init():
     pg = lk.periodogram.Periodogram(np.array([1,1])*units.microhertz, units.Quantity(np.array([1,1]), None))
     st = star('thisisatest', pg, (220.0, 3.0), (16.97, 0.05), (4750, 250), (1.34, 0.1))
     
+    st = star('thisisatest', pg, (220.0, 3.0), (16.97, 0.05), bp_rp = (1.34, 0.1))
+    assert(np.all(np.array(st.teff) != np.array([None,None])))
+
+    st = star('thisisatest', pg, (220.0, 3.0), (16.97, 0.05), teff = (4750, 250))
+    assert(np.all(np.array(st.bp_rp) != np.array([None,None])))
+    
+    with pytest.raises(ValueError):
+        st = star('thisisatest', pg, (220.0, 3.0), (16.97, 0.05))
+
     # simple check to see if all the attributes are there compared to the time
     # of test creation.
     atts = ['ID', '_fill_diag', '_log_obs', '_make_prior_corner', '_obs', 


### PR DESCRIPTION
At least one must be provided though. 

The missing parameters are just replaced by the mean of the prior and a very wide std before it gets fed to KDE. 

Also added unit tests for these parts. 