### PR TITLE
CPnest merge into master

### DIFF
--- a/pbjam/__init__.py
+++ b/pbjam/__init__.py
@@ -12,3 +12,4 @@ from .peakbag import peakbag
 from .ellone import ellone
 from .star import star
 from .mcmc import mcmc
+from .mcmc import nested

--- a/pbjam/asy_peakbag.py
+++ b/pbjam/asy_peakbag.py
@@ -310,6 +310,8 @@ class asymptotic_fit(plotting, asymp_spec_model):
         Dictionary of the observational parameters (input parameters).
     _log_obs : dict
         Dictionary of the observational parametrs in log-scale.
+    prior_data : pandas DataFrame
+        Dataframe containing the samples used to the generate the KDE prior.
     start_samples : ndarray
         Array of samples drawn from the KDE to set the starting location of the
         asymptotic relation fit.
@@ -333,11 +335,13 @@ class asymptotic_fit(plotting, asymp_spec_model):
         self.norders = norders
 
         self._obs = st._obs
-        self._log_obs = st._log_obs          
-        self.prior_file = st.prior_file
+        self._log_obs = st._log_obs    
         
         self.par_names = ['dnu', 'numax', 'eps', 'd02', 'alpha', 'env_height',
                           'env_width', 'mode_width', 'teff', 'bp_rp']
+        
+        self.prior_file = st.prior_file
+        self.prior_data = st.kde.prior_data
         self.start_samples = st.kde.samples       
         self.kde = st.kde.kde    
         self.start = self._get_asy_start()
@@ -385,8 +389,9 @@ class asymptotic_fit(plotting, asymp_spec_model):
             self.fit(start_samples=self.start_samples)
 
         elif method == 'nested':
-            bounds = [[self.start_samples[:, n].min(), 
-                       self.start_samples[:, n].max()] for n in range(len(self.par_names))]
+            #bounds = [[self.start_samples[:, n].min(), 
+            #           self.start_samples[:, n].max()] for n in range(len(self.par_names))]
+            bounds = [[self.prior_data[key].min(), self.prior_data[key].max()] for key in self.par_names]
             self.fit = pb.nested(self.par_names, bounds, self.likelihood, self.prior, self.path)
             self.fit()
          

--- a/pbjam/mcmc.py
+++ b/pbjam/mcmc.py
@@ -8,6 +8,8 @@ Samplers added to PBjam should be called from this module.
 import emcee
 import numpy as np
 import scipy.stats as st
+import cpnest.model
+import pandas as pd
 
 class mcmc():
     """ Class for MCMC sampling using `emcee'
@@ -235,3 +237,75 @@ class mcmc():
             good_mad = st.median_absolute_deviation(flatchains, axis = 0) * spread
             pos[idx, :] = np.array([np.random.randn(self.ndim) * good_mad + good_med for n in range(nbad)])
         return pos
+
+
+class nested(cpnest.model.Model):
+    """
+    Runs CPnest to performed nested sampling from
+
+    log P(theta | D) ~ likelihood + prior
+
+    Note both likelihood and prior are in natural log.
+
+    Attributes
+    ----------
+
+    names: list, strings
+        A list of names of the model parameters
+
+    bounds: list of tuples
+        The bounds of the model parameters as [(0, 10), (-1, 1), ...]
+
+    likelihood: func
+        Function that will return the log likelihood when
+        called as likelihood(params)
+
+    prior: func
+        Function that will return the log prior when called
+        as prior(params)
+
+    """
+    
+    def __init__(self, names, bounds, likelihood, prior):
+        self.names=names
+        self.bounds=bounds
+        self.likelihood = likelihood
+        self.prior = prior
+
+    def log_likelihood(self, param):
+        """ Wrapper for log likelihood """
+        return self.likelihood(param.values)
+
+    def log_prior(self,p):
+        """ Wrapper for log prior """
+        if not self.in_bounds(p): return -np.inf
+        return self.prior(p.values)
+
+    def __call__(self, nlive=100, nthreads=None, maxmcmc=100, poolsize=100, output = './'):
+        """
+        Runs the nested sampling
+
+        Parameters
+        ----------
+        nlive : int
+            ???
+        nthreads : int
+            ???
+        maxmcmc : int
+            ???
+        poolsize : int
+            ???
+
+        Returns
+        -------
+        df: pd.DataFrame
+            A dataframe of the samples produced with the nested sampling.
+        """
+        
+        self.nest = cpnest.CPNest(self, verbose=0, seed=53, nthreads=nthreads,
+                                  nlive=nlive, maxmcmc=maxmcmc, poolsize=poolsize, output=output)
+        self.nest.run()
+        self.samples = pd.DataFrame(self.nest.get_posterior_samples())[self.names]
+        self.flatchain = self.samples.values
+        self.acceptance = np.inf #TODO
+        return self.samples

--- a/pbjam/mcmc.py
+++ b/pbjam/mcmc.py
@@ -258,12 +258,11 @@ class nested(cpnest.model.Model):
         The bounds of the model parameters as [(0, 10), (-1, 1), ...]
 
     likelihood: func
-        Function that will return the log likelihood when
-        called as likelihood(params)
+        Function that will return the log likelihood when called as 
+        likelihood(params)
 
     prior: func
-        Function that will return the log prior when called
-        as prior(params)
+        Function that will return the log prior when called as prior(params)
 
     """
     
@@ -294,24 +293,27 @@ class nested(cpnest.model.Model):
         Parameters
         ----------
         nlive : int
-            ???
+            Number of live points to be used for the sampling. This is similar 
+            to walkers in emcee. Default is 100.
         nthreads : int
-            ???
+            Number of parallel threads to run. More than one is currently slower
+            since the likelihood is fairly quick to evaluate. Default is 1. 
         maxmcmc : int
-            ???
+            Maximum number of mcmc steps taken by the sampler. Default is 100.
         poolsize : int
-            ???
+            Number of objects for the affine invariant sampling. Default is 100.
 
         Returns
         -------
-        df: pd.DataFrame
+        df: pandas DataFrame
             A dataframe of the samples produced with the nested sampling.
         """
         
         self.nest = cpnest.CPNest(self, verbose=0, seed=53, nthreads=nthreads,
-                                  nlive=nlive, maxmcmc=maxmcmc, poolsize=poolsize, output=self.path)
+                                  nlive=nlive, maxmcmc=maxmcmc, 
+                                  poolsize=poolsize, output=self.path)
         self.nest.run()
         self.samples = pd.DataFrame(self.nest.get_posterior_samples())[self.names]
         self.flatchain = self.samples.values
-        self.acceptance = np.inf #TODO
+        self.acceptance = None
         return self.samples

--- a/pbjam/mcmc.py
+++ b/pbjam/mcmc.py
@@ -10,6 +10,7 @@ import numpy as np
 import scipy.stats as st
 import cpnest.model
 import pandas as pd
+import os
 
 class mcmc():
     """ Class for MCMC sampling using `emcee'
@@ -266,11 +267,16 @@ class nested(cpnest.model.Model):
 
     """
     
-    def __init__(self, names, bounds, likelihood, prior):
+    def __init__(self, names, bounds, likelihood, prior, path):
         self.names=names
         self.bounds=bounds
         self.likelihood = likelihood
         self.prior = prior
+        
+        self.path = os.path.join(*[path, 'cpnest'])
+        if not os.path.isdir(self.path):
+            os.mkdir(self.path)
+        
 
     def log_likelihood(self, param):
         """ Wrapper for log likelihood """
@@ -281,7 +287,7 @@ class nested(cpnest.model.Model):
         if not self.in_bounds(p): return -np.inf
         return self.prior(p.values)
 
-    def __call__(self, nlive=100, nthreads=None, maxmcmc=100, poolsize=100, output = './'):
+    def __call__(self, nlive=100, nthreads=1, maxmcmc=100, poolsize=100):
         """
         Runs the nested sampling
 
@@ -303,7 +309,7 @@ class nested(cpnest.model.Model):
         """
         
         self.nest = cpnest.CPNest(self, verbose=0, seed=53, nthreads=nthreads,
-                                  nlive=nlive, maxmcmc=maxmcmc, poolsize=poolsize, output=output)
+                                  nlive=nlive, maxmcmc=maxmcmc, poolsize=poolsize, output=self.path)
         self.nest.run()
         self.samples = pd.DataFrame(self.nest.get_posterior_samples())[self.names]
         self.flatchain = self.samples.values

--- a/pbjam/priors.py
+++ b/pbjam/priors.py
@@ -147,7 +147,7 @@ class kde(plotting):
 
             if not flag_warn:
                 warnings.warn(f'Only {len(pdata[idx])} star(s) near provided numax. ' +
-                'Trying to expand the range to include ~{KDEsize} stars.')
+                f'Trying to expand the range to include ~{KDEsize} stars.')
                 flag_warn = True
 
             if nsigma >= KDEsize:

--- a/pbjam/session.py
+++ b/pbjam/session.py
@@ -733,7 +733,7 @@ class session():
 
     def __call__(self, bw_fac=1, norders=8, model_type='simple', tune=1500, 
                  nthreads=1, verbose=False, make_plots=False, store_chains=False, 
-                 developer_mode=False):
+                 asy_sampling='mcmc', developer_mode=False):
         """ Call all the star class instances
 
         Once initialized, calling the session class instance will loop through
@@ -776,7 +776,7 @@ class session():
                 st(bw_fac=bw_fac, tune=tune, norders=norders, 
                    model_type=self.pb_model_type, make_plots=make_plots, 
                    store_chains=store_chains, nthreads=nthreads, 
-                   developer_mode=developer_mode)
+                   asy_sampling=asy_sampling, developer_mode=developer_mode)
                 
                 self.stars[i] = None
             

--- a/pbjam/star.py
+++ b/pbjam/star.py
@@ -201,7 +201,8 @@ class star(plotting):
                                   savefig=make_plots)
 
     def run_asy_peakbag(self, norders, make_plots=False,
-                        store_chains=False, developer_mode=False):
+                        store_chains=False, method='mcmc', 
+                        developer_mode=False):
         """ Run all steps involving asy_peakbag.
 
         Performs a fit of the asymptotic relation to the spectrum (l=2,0 only),
@@ -215,6 +216,10 @@ class star(plotting):
             Whether or not to produce plots of the results. Default is False.
         store_chains : bool, optional
             Whether or not to store MCMC chains on disk. Default is False.
+        method : string
+            Method to be used for sampling the posterior. Options are 'mcmc' or
+            'nested. Default method is 'mcmc' that will call emcee, alternative
+            is 'nested' to call nested sampling with CPnest.
         developer_mode : bool
             Run asy_peakbag in developer mode. Currently just retains the input 
             value of dnu and numax as priors, for the purposes of expanding
@@ -228,7 +233,7 @@ class star(plotting):
         asymptotic_fit(self, norders=norders)
 
         # Call
-        self.asy_fit(developer_mode)
+        self.asy_fit(method, developer_mode)
 
         # Store
         self.asy_fit.summary.to_csv(self._outpath(f'asymptotic_fit_summary_{self.ID}.csv'),
@@ -290,8 +295,8 @@ class star(plotting):
 
 
     def __call__(self, bw_fac=1.0, norders=8, model_type='simple', tune=1500,
-                 nthreads=1, make_plots=True, store_chains=True,
-                 developer_mode=False):
+                 nthreads=1, make_plots=True, store_chains=True, 
+                 asy_sampling='mcmc', developer_mode=False):
         """ Perform all the PBjam steps
 
         Starts by running KDE, followed by Asy_peakbag and then finally peakbag.
@@ -315,6 +320,10 @@ class star(plotting):
             Whether or not to produce plots of the results. Default is False.
         store_chains : bool, optional.
             Whether or not to store MCMC chains on disk. Default is False.
+        asy_sampling : string
+            Method to be used for sampling the posterior in asy_peakbag. Options
+            are 'mcmc' or 'nested. Default method is 'mcmc' that will call 
+            emcee, alternative is 'nested' to call nested sampling with CPnest.
         developer_mode : bool
             Run asy_peakbag in developer mode. Currently just retains the input 
             value of dnu and numax as priors, for the purposes of expanding
@@ -325,7 +334,7 @@ class star(plotting):
         self.run_kde(bw_fac=bw_fac, make_plots=make_plots)
 
         self.run_asy_peakbag(norders=norders, make_plots=make_plots,
-                             store_chains=store_chains, 
+                             store_chains=store_chains, method=asy_sampling,
                              developer_mode=developer_mode)
 
         self.run_peakbag(model_type=model_type, tune=tune, nthreads=nthreads,

--- a/pbjam/tests/pbjam_tests.py
+++ b/pbjam/tests/pbjam_tests.py
@@ -95,6 +95,7 @@ class case():
         if self.ID == 'silly':
             self.st.kde = type('kde', (object,), {})()
             self.st.kde.samples = np.ones((2,10))
+            self.st.kde.prior_data = np.ones((2,10))
             
             data = np.array(self.pars['asypars']).repeat(11).reshape((10,-1))
             self.st.kde.kde = sm.nonparametric.KDEMultivariate(data=data, var_type='cccccccccc', bw='scott')

--- a/pbjam/tests/test_asy_peakbag.py
+++ b/pbjam/tests/test_asy_peakbag.py
@@ -68,7 +68,7 @@ def test_get_summary_stats():
     # simple tests
     pbt.does_it_return(func, inp)
     pbt.right_type(func, inp, pd.DataFrame)
-    pbt.right_shape(func, inp, (10,10))
+    pbt.right_shape(func, inp, (10, 9))
 
     out = func(*inp)
 
@@ -78,8 +78,8 @@ def test_get_summary_stats():
         assert_array_equal(out.loc[:, key], 0)
     
     # same as above
-    for key in ['mle', 'mean', '2nd', '16th', '50th', '84th', '97th']:
-        assert_array_equal(out.loc[:,'mle'], np.array([ 1.,  2.,  1.,  0., -2.,  1.,  1.,  1.,  1.,  1.]))
+    for key in ['mean', '2nd', '16th', '50th', '84th', '97th']:
+        assert_array_equal(out.loc[:,key], np.array([ 1.,  2.,  1.,  0., -2.,  1.,  1.,  1.,  1.,  1.]))
   
 def test_prior_function():
     """Tests for the prior function used by asy_fit"""


### PR DESCRIPTION
This PR merges the CPnest bits of the branch #232  into master (there are reggae bits that are not merged). 

Optional arguments are put into session, star and asy_peakbag to pick the sampling method. 

CPnest apparently dumps a lot of stuff in cwd. This is now sent to a cpnest subdirectory in the star directory instead. 

Questions for @grd349 
- self.acceptance= np.inf in the nested class is TODO. What is this?
- In asy_peakbag, min/max of the samples from KDE are used to set the bounds of CPnest. These samples are drawn from the kde,, but in using the min/max of the sample, are we not effectively truncating the KDE prior? 
