### PR TITLE
Adding references- PBjam is now 0.1% TeX

### DIFF
--- a/Examples/Example-references.ipynb
+++ b/Examples/Example-references.ipynb
@@ -1,0 +1,219 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Listing your references with PBjam\n",
+    "This tutorial will show you how to get PBjam to list the publications you have made use of when using the different parts of PBjam.\n",
+    "\n",
+    "Below we will use [session](https://pbjam.readthedocs.io/en/latest/session.html#pbjam.session.session) as an example, but the same methods apply to the [star](https://pbjam.readthedocs.io/en/latest/star.html#pbjam.star.star) class.\n",
+    "\n",
+    "When initializing a list of references will automatically be compiled for the setup part of the run. This list will be updated during your the run, depending on which parts of PBjam you use."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Checkpoint exception raise\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2020-07-24, 01:33:18 - theano.tensor.blas: Using NumPy C-API based implementation for BLAS functions.\n",
+      "2020-07-24, 01:33:18 - theano.tensor.blas: Using NumPy C-API based implementation for BLAS functions.\n"
+     ]
+    }
+   ],
+   "source": [
+    "import pbjam as pb\n",
+    "sess = pb.session(ID='KIC4448777', \n",
+    "                  numax=(220.0, 3.0), \n",
+    "                  dnu=(16.97, 0.05), \n",
+    "                  teff=(4750, 250), \n",
+    "                  bp_rp=(1.34, 0.1),\n",
+    "                  path = '.')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The references list in bibtex format can then be retrieved by using the references method. You can specify a optionally specify file to print the result to by using the bibfile argument."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "References used in this run.\n",
+      "@book{python1995, \n",
+      "  title={Python tutorial}, \n",
+      "  author={Van Rossum, Guido and Drake Jr, Fred L}, \n",
+      "  year={1995}, \n",
+      "  publisher={Centrum voor Wiskunde en Informatica Amsterdam, The Netherlands} \n",
+      "}\n"
+     ]
+    }
+   ],
+   "source": [
+    "sess.references(bibfile = 'myfile.bib')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This list only contains the basic packages that PBjam uses when initializing the class (and Python itself of course).\n",
+    "\n",
+    "Now lets populate the list some more using by completing the peakbagging run."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Starting KDE estimation\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/nielsemb/work/repos/PBjam/pbjam/priors.py:151: UserWarning: Only 61 star(s) near provided numax. Trying to expand the range to include ~100 stars.\n",
+      "  f'Trying to expand the range to include ~{KDEsize} stars.')\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Steps taken: 2000\n",
+      "Steps taken: 3000\n",
+      "Steps taken: 4000\n",
+      "Steps taken: 5000\n",
+      "Chains reached stationary state after 5000 iterations.\n",
+      "Starting asymptotic peakbagging\n",
+      "Steps taken: 2000\n",
+      "Chains reached stationary state after 2000 iterations.\n",
+      "Starting peakbagging\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2020-07-24, 01:39:12 - pymc3   : Auto-assigning NUTS sampler...\n",
+      "2020-07-24, 01:39:12 - pymc3   : Initializing NUTS using adapt_diag...\n",
+      "2020-07-24, 01:39:18 - pymc3   : Sequential sampling (2 chains in 1 job)\n",
+      "2020-07-24, 01:39:18 - pymc3   : NUTS: [back, height2, height0, l2, l0, width2, width0]\n"
+     ]
+    }
+   ],
+   "source": [
+    "sess(norders=7)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "References used in this run.\n",
+      "@ARTICLE{Evans2018,\n",
+      "       author = {{Evans}, D.~W. and {Riello}, M. and {De Angeli}, F. and\n",
+      "         {Carrasco}, J.~M. and {Montegriffo}, P. and {Fabricius}, C. and\n",
+      "         {Jordi}, C. and {Palaversa}, L. and {Diener}, C. and {Busso}, G. and\n",
+      "         {Cacciari}, C. and {van Leeuwen}, F. and {Burgess}, P.~W. and\n",
+      "         {Davidson}, M. and {Harrison}, D.~L. and {Hodgkin}, S.~T. and\n",
+      "         {Pancino}, E. and {Richards}, P.~J. and {Altavilla}, G. and\n",
+      "         {Balaguer-N{\\'u}{\\~n}ez}, L. and {Barstow}, M.~A. and {Bellazzini}, M. and\n",
+      "         {Brown}, A.~G.~A. and {Castellani}, M. and {Cocozza}, G. and\n",
+      "         {De Luise}, F. and {Delgado}, A. and {Ducourant}, C. and {Galleti}, S. and\n",
+      "         {Gilmore}, G. and {Giuffrida}, G. and {Holl}, B. and {Kewley}, A. and\n",
+      "         {Koposov}, S.~E. and {Marinoni}, S. and {Marrese}, P.~M. and\n",
+      "         {Osborne}, P.~J. and {Piersimoni}, A. and {Portell}, J. and\n",
+      "         {Pulone}, L. and {Ragaini}, S. and {Sanna}, N. and {Terrett}, D. and\n",
+      "         {Walton}, N.~A. and {Wevers}, T. and {Wyrzykowski}, {\\L}.},\n",
+      "        title = \"{Gaia Data Release 2. Photometric content and validation}\",\n",
+      "      journal = {\\aap},\n",
+      "     keywords = {catalogs, surveys, instrumentation: photometers, techniques: photometric, galaxies: general, Astrophysics - Instrumentation and Methods for Astrophysics},\n",
+      "         year = 2018,\n",
+      "        month = aug,\n",
+      "       volume = {616},\n",
+      "          eid = {A4},\n",
+      "        pages = {A4},\n",
+      "          doi = {10.1051/0004-6361/201832756},\n",
+      "archivePrefix = {arXiv},\n",
+      "       eprint = {1804.09368},\n",
+      " primaryClass = {astro-ph.IM},\n",
+      "       adsurl = {https://ui.adsabs.harvard.edu/abs/2018A&A...616A...4E},\n",
+      "      adsnote = {Provided by the SAO/NASA Astrophysics Data System}\n",
+      "}\n",
+      "\n",
+      "@book{Oliphant2006, \n",
+      "  title={A guide to NumPy}, \n",
+      "  author={Oliphant, Travis E}, \n",
+      "  volume={1}, \n",
+      "  year={2006}, \n",
+      "  publisher={Trelgol Publishing USA} \n",
+      "}\n",
+      "\n",
+      "@book{python1995, \n",
+      "  title={Python tutorial}, \n",
+      "  author={Van Rossum, Guido and Drake Jr, Fred L}, \n",
+      "  year={1995}, \n",
+      "  publisher={Centrum voor Wiskunde en Informatica Amsterdam, The Netherlands} \n",
+      "}\n"
+     ]
+    }
+   ],
+   "source": [
+    "sess.references()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/README.rst
+++ b/README.rst
@@ -37,9 +37,9 @@ If you want to raise and issue or contribute code to PBjam, see the `guidelines 
 
 Authors
 -------
-================= =============== ====================
-Main Contributors Chaos Engineers Scientific Oversight
-================= =============== ====================
+===================================================== ================================================ ====================
+Main Contributors                                     Chaos Engineers                                  Scientific Oversight
+===================================================== ================================================ ====================
 `Lindsey Carboneau <https://github.com/lmcarboneau>`_ `Warrick Ball <https://github.com/warrickball>`_ Othman Benomar
 cell              cell            cell
-================= =============== ====================
+===================================================== ================================================ ====================

--- a/README.rst
+++ b/README.rst
@@ -41,15 +41,14 @@ Authors
 Main Contributors                                     Chaos Engineers                                  Scientific Influencers
 ===================================================== ================================================ ======================
 `Lindsey Carboneau <https://github.com/lmcarboneau>`_ `Warrick Ball <https://github.com/warrickball>`_ Othman Benomar
-`Guy Davies <https://github.com/grd349>`_	          `Joel Ong <https://github.com/darthoctopus>`_	   Othman Benomar
-`Oliver Hall <https://github.com/ojhall94>`_	      `Tanda Li <https://github.com/litanda>`_	       Bill Chaplin
-`Alex Lyttle <https://github.com/alexlyttle>`_	      `Rafa Garcia <https://github.com/rgarcibus>`_	   Enrico Corsaro
-`Martin Nielsen <https://github.com/nielsenmb>`_		                                               Patrick Gaulme
-		                                                                                               Benoit Mosser
-		                                                                                               Andy Moya
-		                                                                                               Ian Roxburgh
-		                                                                                               Mikkel Lund
-		                                                                                               Benoit Mosser
-		                                                                                               Andy Moya
-		                                                                                               Ian Roxburgh
+`Guy Davies <https://github.com/grd349>`_	      `Joel Ong <https://github.com/darthoctopus>`_    Bill Chaplin
+`Oliver Hall <https://github.com/ojhall94>`_	      `Tanda Li <https://github.com/litanda>`_	       Enrico Corsaro
+`Alex Lyttle <https://github.com/alexlyttle>`_	      `Rafa Garcia <https://github.com/rgarcibus>`_    Patrick Gaulme   
+`Martin Nielsen <https://github.com/nielsenmb>`_		                                       Benoit Mosser
+		                                                                                       Andy Moya
+		                                                                                       Ian Roxburgh
+		                                                                                       Mikkel Lund
+		                                                                                       Benoit Mosser
+		                                                                                       Andy Moya
+		                                                                                       Ian Roxburgh
 ===================================================== ================================================ ======================

--- a/README.rst
+++ b/README.rst
@@ -45,5 +45,5 @@ Main Contributors                                     Chaos Engineers           
 `Oliver Hall <https://github.com/ojhall94>`_	      `Tanda Li <https://github.com/litanda>`_	       Enrico Corsaro
 `Alex Lyttle <https://github.com/alexlyttle>`_	      `Rafa Garcia <https://github.com/rgarcibus>`_    Patrick Gaulme   
 `Martin Nielsen <https://github.com/nielsenmb>`_                                                       Benoit Mosser
-                                                                                                       Andy Moya
+|                                                     |                                                Andy Moya
 ===================================================== ================================================ ======================

--- a/README.rst
+++ b/README.rst
@@ -37,18 +37,15 @@ If you want to raise and issue or contribute code to PBjam, see the `guidelines 
 
 Authors
 -------
-===================================================== ================================================ ======================
+===================================================== ================================================ ====================================================
 Main Contributors                                     Chaos Engineers                                  Scientific Influencers
-===================================================== ================================================ ======================
-`Lindsey Carboneau <https://github.com/lmcarboneau>`_ `Warrick Ball <https://github.com/warrickball>`_ Othman Benomar
-`Guy Davies <https://github.com/grd349>`_	      `Joel Ong <https://github.com/darthoctopus>`_    Bill Chaplin
-`Oliver Hall <https://github.com/ojhall94>`_	      `Tanda Li <https://github.com/litanda>`_	       Enrico Corsaro
-`Alex Lyttle <https://github.com/alexlyttle>`_	      `Rafa Garcia <https://github.com/rgarcibus>`_    Patrick Gaulme   
+===================================================== ================================================ ====================================================
+`Lindsey Carboneau <https://github.com/lmcarboneau>`_ `Warrick Ball <https://github.com/warrickball>`_ `Othman Benomar <https://github.com/OthmanB>`_
+`Guy Davies <https://github.com/grd349>`_             `Joel Ong <https://github.com/darthoctopus>`_    Bill Chaplin 
+`Oliver Hall <https://github.com/ojhall94>`_          `Tanda Li <https://github.com/litanda>`_	       `Enrico Corsaro <https://github.com/EnricoCorsaro>`_
+`Alex Lyttle <https://github.com/alexlyttle>`_        `Rafa Garcia <https://github.com/rgarcibus>`_    `Patrick Gaulme <https://github.com/gaulme>`_  
 `Martin Nielsen <https://github.com/nielsenmb>`_      |                                                Benoit Mosser
 |                                                     |                                                Andy Moya
 |                                                     |                                                Ian Roxburgh
-|                                                     |                                                Mikkel Lund
-|                                                     |                                                Benoit Mosser
-|                                                     |                                                Andy Moya
-|                                                     |                                                Ian Roxburgh
-===================================================== ================================================ ======================
+|                                                     |                                                `Mikkel Lund <https://github.com/Miklnl>`_
+===================================================== ================================================ ====================================================

--- a/README.rst
+++ b/README.rst
@@ -39,6 +39,5 @@ Authors
 -------
 .. csv-table:: a title
    :file: https://github.com/grd349/PBjam/blob/master/authors.csv
-   :widths: 20, 20, 20
 
 

--- a/README.rst
+++ b/README.rst
@@ -40,6 +40,6 @@ Authors
 ================= =============== ====================
 Main Contributors Chaos Engineers Scientific Oversight
 ================= =============== ====================
-`Lindsey Carboneau <https://github.com/lmcarboneau>`_   cell      cell
-cell  cell      cell
-================= ========= =====
+cell              cell            cell
+cell              cell            cell
+================= =============== ====================

--- a/README.rst
+++ b/README.rst
@@ -45,10 +45,5 @@ Main Contributors                                     Chaos Engineers           
 `Oliver Hall <https://github.com/ojhall94>`_	      `Tanda Li <https://github.com/litanda>`_	       Enrico Corsaro
 `Alex Lyttle <https://github.com/alexlyttle>`_	      `Rafa Garcia <https://github.com/rgarcibus>`_    Patrick Gaulme   
 `Martin Nielsen <https://github.com/nielsenmb>`_		                                       Benoit Mosser
-		                                                                                       Andy Moya
-		                                                                                       Ian Roxburgh
-		                                                                                       Mikkel Lund
-		                                                                                       Benoit Mosser
-		                                                                                       Andy Moya
-		                                                                                       Ian Roxburgh
+                                                                                                       Andy Moya
 ===================================================== ================================================ ======================

--- a/README.rst
+++ b/README.rst
@@ -39,5 +39,7 @@ Authors
 -------
 .. csv-table:: a title
    :file: https://github.com/grd349/PBjam/blob/master/authors.csv
+   :widths: 33 33 33
+   :header-row: 1
 
 

--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,17 @@ If you want to raise and issue or contribute code to PBjam, see the `guidelines 
 Authors
 -------
 .. csv-table:: a title
-   :file: authors.csv
-   :header-rows: 1
-   :widths: 33 33 33
+    :header: Main Contributors,Chaos Engineers,Scientific Oversight
+    `Lindsey Carboneau <https://github.com/lmcarboneau>`_,`Warrick Ball <https://github.com/warrickball>`_,Othman Benomar
+    `Guy Davies <https://github.com/grd349>`_,`Joel Ong <https://github.com/darthoctopus>`_,Othman Benomar
+    `Oliver Hall <https://github.com/ojhall94>`_,`Tanda Li <https://github.com/litanda>`_,Bill Chaplin
+    `Alex Lyttle <https://github.com/alexlyttle>`_,`Rafa Garcia <https://github.com/rgarcibus>`_,Enrico Corsaro
+    `Martin Nielsen <https://github.com/nielsenmb>`_,,Patrick Gaulme
+    ,,Benoit Mosser
+    ,,Andy Moya
+    ,,Ian Roxburgh
+    ,,Mikkel Lund
+    ,,Benoit Mosser
+    ,,Andy Moya
+    ,,Ian Roxburgh
 

--- a/README.rst
+++ b/README.rst
@@ -41,4 +41,5 @@ Authors
 Table Headings  Here
 ===== ========= =====
 cell  cell      cell
+cell  cell      cell
 ===== ========= =====

--- a/README.rst
+++ b/README.rst
@@ -55,5 +55,5 @@ Acknowledgements
 ----------------
 If you use PBjam in your work please cite the PBjam paper (forthcoming), and if possible provide links to the GitHub repository. 
 
-We encourage PBjam users to also cite the packages that PBjam makes use of. To get a list of publications that your peakbagging run made use of, the :mod:`~pbjam.session` and :mod:`~pbjam.star` classes have a handy references method, that can be called after you have performed your run. This will list all the bibtex entries you require for citing the relevant publications.
+We encourage PBjam users to also cite the packages that PBjam makes use of. PBjam can list the publications that were used during a run (see the `Reference Examples Notebook <https://github.com/grd349/PBjam/tree/master/Examples/Example-references.ipynb>`_.
 

--- a/README.rst
+++ b/README.rst
@@ -35,10 +35,8 @@ Contributing
 If you want to raise and issue or contribute code to PBjam, see the `guidelines on contributing <https://github.com/grd349/PBjam/blob/master/CONTRIBUTING.rst>`_.
 
 
-Authors
--------
-.. tabularcolumns:: |p{7cm}|p{7cm}|
-.. csv-table:: Table Title
+
+.. csv-table:: Authors
    :file: authors.csv
    :widths: 30, 70
    :header-rows: 1

--- a/README.rst
+++ b/README.rst
@@ -38,14 +38,7 @@ If you want to raise and issue or contribute code to PBjam, see the `guidelines 
 Authors
 -------
 .. csv-table:: a title
-   :header: "Main Contributors", "Chaos Engineers", "Scientific Oversight"
+   :file: authors.csv
+   :header-rows: 1
    :widths: 33 33 33
-   `Lindsey Carboneau <https://github.com/lmcarboneau>`_,`Warrick Ball <https://github.com/warrickball>`_,Othman Benomar
-   `Guy Davies <https://github.com/grd349>`_,`Joel Ong <https://github.com/darthoctopus>`_,Bill Chaplin
-   `Oliver Hall <https://github.com/ojhall94>`_,`Tanda Li <https://github.com/litanda>`_,Enrico Corsaro
-   `Alex Lyttle <https://github.com/alexlyttle>`_,`Rafa Garcia <https://github.com/rgarcibus>`_,Patrick Gaulme
-   `Martin Nielsen <https://github.com/nielsenmb>`_,,Mikkel Lund
-   ,,Benoit Mosser
-   ,,Andy Moya
-   ,,Ian Roxburgh
 

--- a/README.rst
+++ b/README.rst
@@ -37,17 +37,7 @@ If you want to raise and issue or contribute code to PBjam, see the `guidelines 
 
 Authors
 -------
-Main Contributors
-^^^^^^^^^^^^^^^^^
-- `Guy Davies <https://github.com/grd349>`_
-- `Martin Nielsen <https://github.com/nielsenmb>`_
-- `Alex Lyttle <https://github.com/alexlyttle>`_
-- `Oliver Hall <https://github.com/ojhall94>`_
-
-Chaos Engineers
-^^^^^^^^^^^^^^^
-- `Warrick Ball <https://github.com/warrickball>`_
-- `Joel Ong <https://github.com/darthoctopus>`_
-- Bill Chaplin
-- `Tanda Li <https://github.com/litanda>`_
-- `Rafa Garcia <https://github.com/rgarcibus>`_
+.. csv-table:: Table Title
+   :file: authors.csv
+   :widths: 30, 70
+   :header-rows: 1

--- a/README.rst
+++ b/README.rst
@@ -37,6 +37,7 @@ If you want to raise and issue or contribute code to PBjam, see the `guidelines 
 Authors
 -------
 There are different ways to contribute to PBjam, the Scientific Influencers help guide the scientific aspects of PBjam, the Chaos Engineers try to break the code or simply report bugs, while the Main Contributors submit Pull Requests with somewhat bigger additions to the code or documentation. 
+
 ===================================================== ================================================ ====================================================
 Main Contributors                                     Chaos Engineers                                  Scientific Influencers
 ===================================================== ================================================ ====================================================

--- a/README.rst
+++ b/README.rst
@@ -55,5 +55,5 @@ Acknowledgements
 ----------------
 If you use PBjam in your work please cite the PBjam paper (forthcoming), and if possible provide links to the GitHub repository. 
 
-We encourage PBjam users to also cite the packages that PBjam makes use of. PBjam can list the publications that were used during a run (see the `Reference Examples Notebook <https://github.com/grd349/PBjam/tree/master/Examples/Example-references.ipynb>`_.
+We encourage PBjam users to also cite the packages that PBjam makes use of. PBjam can list the publications that were used during a run (see the `Referencing Notebook <https://github.com/grd349/PBjam/tree/master/Examples/Example-references.ipynb>`_).
 

--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ If you want to raise and issue or contribute code to PBjam, see the `guidelines 
 Authors
 -------
 .. csv-table:: a title
-   :file: https://github.com/grd349/PBjam/blob/master/authors.csv
+   :file: https://github.com/nielsenmb/PBjam/blob/master/authors.csv
    :widths: 33 33 33
    :header-row: 1
 

--- a/README.rst
+++ b/README.rst
@@ -37,9 +37,19 @@ If you want to raise and issue or contribute code to PBjam, see the `guidelines 
 
 Authors
 -------
-===================================================== ================================================ ====================
-Main Contributors                                     Chaos Engineers                                  Scientific Oversight
-===================================================== ================================================ ====================
+===================================================== ================================================ ======================
+Main Contributors                                     Chaos Engineers                                  Scientific Influencers
+===================================================== ================================================ ======================
 `Lindsey Carboneau <https://github.com/lmcarboneau>`_ `Warrick Ball <https://github.com/warrickball>`_ Othman Benomar
-cell              cell            cell
-===================================================== ================================================ ====================
+`Guy Davies <https://github.com/grd349>`_	          `Joel Ong <https://github.com/darthoctopus>`_	   Othman Benomar
+`Oliver Hall <https://github.com/ojhall94>`_	      `Tanda Li <https://github.com/litanda>`_	       Bill Chaplin
+`Alex Lyttle <https://github.com/alexlyttle>`_	      `Rafa Garcia <https://github.com/rgarcibus>`_	   Enrico Corsaro
+`Martin Nielsen <https://github.com/nielsenmb>`_		                                               Patrick Gaulme
+		                                                                                               Benoit Mosser
+		                                                                                               Andy Moya
+		                                                                                               Ian Roxburgh
+		                                                                                               Mikkel Lund
+		                                                                                               Benoit Mosser
+		                                                                                               Andy Moya
+		                                                                                               Ian Roxburgh
+===================================================== ================================================ ======================

--- a/README.rst
+++ b/README.rst
@@ -41,5 +41,4 @@ Authors
    :header: "name", "firstname", "age"
    :widths: 20, 20, 10
 
-   "Smith", "John", 40
-   "Smith", "John, Junior", 20
+   :file: https://github.com/grd349/PBjam/blob/master/authors.csv

--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,16 @@ If you want to raise and issue or contribute code to PBjam, see the `guidelines 
 Authors
 -------
 .. csv-table:: a title
-   :file: https://github.com/nielsenmb/PBjam/blob/master/authors.csv
+   
    :header: "Main Contributors"	"Chaos Engineers" "Scientific Oversight"
-   :widths: 33 33 33
+   
+   `Lindsey Carboneau <https://github.com/lmcarboneau>`_,`Warrick Ball <https://github.com/warrickball>`_,Othman Benomar
+    `Guy Davies <https://github.com/grd349>`_,`Joel Ong <https://github.com/darthoctopus>`_,Bill Chaplin
+    `Oliver Hall <https://github.com/ojhall94>`_,`Tanda Li <https://github.com/litanda>`_,Enrico Corsaro
+    `Alex Lyttle <https://github.com/alexlyttle>`_,`Rafa Garcia <https://github.com/rgarcibus>`_,Patrick Gaulme
+    `Martin Nielsen <https://github.com/nielsenmb>`_,
+    ,,Mikkel Lund
+    ,,Benoit Mosser
+    ,,Andy Moya
+    ,,Ian Roxburgh
 

--- a/README.rst
+++ b/README.rst
@@ -37,9 +37,9 @@ If you want to raise and issue or contribute code to PBjam, see the `guidelines 
 
 Authors
 -------
-===== ========= =====
-Table Headings  Here
-===== ========= =====
+================= =============== ====================
+Main Contributors Chaos Engineers Scientific Oversight
+================= =============== ====================
+`Lindsey Carboneau <https://github.com/lmcarboneau>`_   cell      cell
 cell  cell      cell
-cell  cell      cell
-===== ========= =====
+================= ========= =====

--- a/README.rst
+++ b/README.rst
@@ -41,9 +41,9 @@ Authors
 Main Contributors                                     Chaos Engineers                                  Scientific Influencers
 ===================================================== ================================================ ====================================================
 `Lindsey Carboneau <https://github.com/lmcarboneau>`_ `Warrick Ball <https://github.com/warrickball>`_ `Othman Benomar <https://github.com/OthmanB>`_
-`Guy Davies <https://github.com/grd349>`_             `Joel Ong <https://github.com/darthoctopus>`_    Bill Chaplin 
+`Guy Davies <https://github.com/grd349>`_             `Rafa Garcia <https://github.com/rgarcibus>`_    Bill Chaplin 
 `Oliver Hall <https://github.com/ojhall94>`_          `Tanda Li <https://github.com/litanda>`_	       `Enrico Corsaro <https://github.com/EnricoCorsaro>`_
-`Alex Lyttle <https://github.com/alexlyttle>`_        `Rafa Garcia <https://github.com/rgarcibus>`_    `Patrick Gaulme <https://github.com/gaulme>`_  
+`Alex Lyttle <https://github.com/alexlyttle>`_        `Joel Ong <https://github.com/darthoctopus>`_    `Patrick Gaulme <https://github.com/gaulme>`_  
 `Martin Nielsen <https://github.com/nielsenmb>`_      |                                                `Mikkel Lund <https://github.com/Miklnl>`_
 |                                                     |                                                Benoit Mosser 
 |                                                     |                                                Andy Moya

--- a/README.rst
+++ b/README.rst
@@ -37,6 +37,7 @@ If you want to raise and issue or contribute code to PBjam, see the `guidelines 
 
 Authors
 -------
+.. tabularcolumns:: |p{7cm}|p{7cm}|
 .. csv-table:: Table Title
    :file: authors.csv
    :widths: 30, 70

--- a/README.rst
+++ b/README.rst
@@ -44,8 +44,8 @@ Main Contributors                                     Chaos Engineers           
 `Guy Davies <https://github.com/grd349>`_             `Joel Ong <https://github.com/darthoctopus>`_    Bill Chaplin 
 `Oliver Hall <https://github.com/ojhall94>`_          `Tanda Li <https://github.com/litanda>`_	       `Enrico Corsaro <https://github.com/EnricoCorsaro>`_
 `Alex Lyttle <https://github.com/alexlyttle>`_        `Rafa Garcia <https://github.com/rgarcibus>`_    `Patrick Gaulme <https://github.com/gaulme>`_  
-`Martin Nielsen <https://github.com/nielsenmb>`_      |                                                Benoit Mosser
+`Martin Nielsen <https://github.com/nielsenmb>`_      |                                                `Mikkel Lund <https://github.com/Miklnl>`_
+|                                                     |                                                Benoit Mosser 
 |                                                     |                                                Andy Moya
 |                                                     |                                                Ian Roxburgh
-|                                                     |                                                `Mikkel Lund <https://github.com/Miklnl>`_
 ===================================================== ================================================ ====================================================

--- a/README.rst
+++ b/README.rst
@@ -40,6 +40,6 @@ Authors
 ================= =============== ====================
 Main Contributors Chaos Engineers Scientific Oversight
 ================= =============== ====================
-cell              cell            cell
+`Lindsey Carboneau <https://github.com/lmcarboneau>`_ `Warrick Ball <https://github.com/warrickball>`_ Othman Benomar
 cell              cell            cell
 ================= =============== ====================

--- a/README.rst
+++ b/README.rst
@@ -38,16 +38,14 @@ If you want to raise and issue or contribute code to PBjam, see the `guidelines 
 Authors
 -------
 .. csv-table:: a title
-   
-   :header: "Main Contributors"	"Chaos Engineers" "Scientific Oversight"
-   
+   :header: "Main Contributors", "Chaos Engineers", "Scientific Oversight"
+   :widths: 33 33 33
    `Lindsey Carboneau <https://github.com/lmcarboneau>`_,`Warrick Ball <https://github.com/warrickball>`_,Othman Benomar
-    `Guy Davies <https://github.com/grd349>`_,`Joel Ong <https://github.com/darthoctopus>`_,Bill Chaplin
-    `Oliver Hall <https://github.com/ojhall94>`_,`Tanda Li <https://github.com/litanda>`_,Enrico Corsaro
-    `Alex Lyttle <https://github.com/alexlyttle>`_,`Rafa Garcia <https://github.com/rgarcibus>`_,Patrick Gaulme
-    `Martin Nielsen <https://github.com/nielsenmb>`_,
-    ,,Mikkel Lund
-    ,,Benoit Mosser
-    ,,Andy Moya
-    ,,Ian Roxburgh
+   `Guy Davies <https://github.com/grd349>`_,`Joel Ong <https://github.com/darthoctopus>`_,Bill Chaplin
+   `Oliver Hall <https://github.com/ojhall94>`_,`Tanda Li <https://github.com/litanda>`_,Enrico Corsaro
+   `Alex Lyttle <https://github.com/alexlyttle>`_,`Rafa Garcia <https://github.com/rgarcibus>`_,Patrick Gaulme
+   `Martin Nielsen <https://github.com/nielsenmb>`_,,Mikkel Lund
+   ,,Benoit Mosser
+   ,,Andy Moya
+   ,,Ian Roxburgh
 

--- a/README.rst
+++ b/README.rst
@@ -35,8 +35,9 @@ Contributing
 If you want to raise and issue or contribute code to PBjam, see the `guidelines on contributing <https://github.com/grd349/PBjam/blob/master/CONTRIBUTING.rst>`_.
 
 
-
+Authors
+-------
 .. csv-table:: Authors
-   :file: authors.csv
+   :file: https://github.com/grd349/PBjam/blob/master/authors.rst
    :widths: 30, 70
    :header-rows: 1

--- a/README.rst
+++ b/README.rst
@@ -44,6 +44,11 @@ Main Contributors                                     Chaos Engineers           
 `Guy Davies <https://github.com/grd349>`_	      `Joel Ong <https://github.com/darthoctopus>`_    Bill Chaplin
 `Oliver Hall <https://github.com/ojhall94>`_	      `Tanda Li <https://github.com/litanda>`_	       Enrico Corsaro
 `Alex Lyttle <https://github.com/alexlyttle>`_	      `Rafa Garcia <https://github.com/rgarcibus>`_    Patrick Gaulme   
-`Martin Nielsen <https://github.com/nielsenmb>`_                                                       Benoit Mosser
+`Martin Nielsen <https://github.com/nielsenmb>`_      |                                                Benoit Mosser
 |                                                     |                                                Andy Moya
+|                                                     |                                                Ian Roxburgh
+|                                                     |                                                Mikkel Lund
+|                                                     |                                                Benoit Mosser
+|                                                     |                                                Andy Moya
+|                                                     |                                                Ian Roxburgh
 ===================================================== ================================================ ======================

--- a/README.rst
+++ b/README.rst
@@ -49,3 +49,11 @@ Main Contributors                                     Chaos Engineers           
 |                                                     |                                                Andy Moya
 |                                                     |                                                Ian Roxburgh
 ===================================================== ================================================ ====================================================
+
+
+Acknowledgements
+----------------
+If you use PBjam in your work please cite the PBjam paper (forthcoming), and if possible provide links to the GitHub repository. 
+
+We encourage PBjam users to also cite the packages that PBjam makes use of. To get a list of publications that your peakbagging run made use of, the :mod:`~pbjam.session` and :mod:`~pbjam.star` classes have a handy references method, that can be called after you have performed your run. This will list all the bibtex entries you require for citing the relevant publications.
+

--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,9 @@ If you want to raise and issue or contribute code to PBjam, see the `guidelines 
 
 Authors
 -------
-.. csv-table:: Authors
-   :file: https://github.com/grd349/PBjam/blob/master/authors.rst
-   :widths: 30, 70
-   :header-rows: 1
+.. csv-table:: a title
+   :header: "name", "firstname", "age"
+   :widths: 20, 20, 10
+
+   "Smith", "John", 40
+   "Smith", "John, Junior", 20

--- a/README.rst
+++ b/README.rst
@@ -37,18 +37,11 @@ If you want to raise and issue or contribute code to PBjam, see the `guidelines 
 
 Authors
 -------
-.. csv-table:: a title
-    :header: Main Contributors,Chaos Engineers,Scientific Oversight
-    `Lindsey Carboneau <https://github.com/lmcarboneau>`_,`Warrick Ball <https://github.com/warrickball>`_,Othman Benomar
-    `Guy Davies <https://github.com/grd349>`_,`Joel Ong <https://github.com/darthoctopus>`_,Othman Benomar
-    `Oliver Hall <https://github.com/ojhall94>`_,`Tanda Li <https://github.com/litanda>`_,Bill Chaplin
-    `Alex Lyttle <https://github.com/alexlyttle>`_,`Rafa Garcia <https://github.com/rgarcibus>`_,Enrico Corsaro
-    `Martin Nielsen <https://github.com/nielsenmb>`_,,Patrick Gaulme
-    ,,Benoit Mosser
-    ,,Andy Moya
-    ,,Ian Roxburgh
-    ,,Mikkel Lund
-    ,,Benoit Mosser
-    ,,Andy Moya
-    ,,Ian Roxburgh
-
+=====  =====  ======
+  A      B    A or B
+=====  =====  ======
+`Lindsey Carboneau <https://github.com/lmcarboneau>`_  `Warrick Ball <https://github.com/warrickball>`_  Othman Benomar
+`Guy Davies <https://github.com/grd349>`_   `Joel Ong <https://github.com/darthoctopus>`_  Othman Benomar
+`Oliver Hall <https://github.com/ojhall94>`_  `Tanda Li <https://github.com/litanda>`_   Bill Chaplin
+True   True   True
+=====  =====  ======

--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,8 @@ If you want to raise and issue or contribute code to PBjam, see the `guidelines 
 Authors
 -------
 .. csv-table:: a title
+   :file: https://github.com/grd349/PBjam/blob/master/authors.csv
    :header: "name", "firstname", "age"
    :widths: 20, 20, 10
 
-   :file: https://github.com/grd349/PBjam/blob/master/authors.csv
+

--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,6 @@ Authors
 -------
 .. csv-table:: a title
    :file: https://github.com/grd349/PBjam/blob/master/authors.csv
-   :header: "name", "firstname", "age"
-   :widths: 20, 20, 10
+   :widths: 20, 20, 20
 
 

--- a/README.rst
+++ b/README.rst
@@ -44,6 +44,6 @@ Main Contributors                                     Chaos Engineers           
 `Guy Davies <https://github.com/grd349>`_	      `Joel Ong <https://github.com/darthoctopus>`_    Bill Chaplin
 `Oliver Hall <https://github.com/ojhall94>`_	      `Tanda Li <https://github.com/litanda>`_	       Enrico Corsaro
 `Alex Lyttle <https://github.com/alexlyttle>`_	      `Rafa Garcia <https://github.com/rgarcibus>`_    Patrick Gaulme   
-`Martin Nielsen <https://github.com/nielsenmb>`_		                                       Benoit Mosser
+`Martin Nielsen <https://github.com/nielsenmb>`_                                                       Benoit Mosser
                                                                                                        Andy Moya
 ===================================================== ================================================ ======================

--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,6 @@ Authors
 -------
 .. csv-table:: a title
    :file: https://github.com/nielsenmb/PBjam/blob/master/authors.csv
+   :header: "Main Contributors"	"Chaos Engineers" "Scientific Oversight"
    :widths: 33 33 33
-   :header-row: 1
-
 

--- a/README.rst
+++ b/README.rst
@@ -39,11 +39,6 @@ Authors
 -------
 ===== ========= =====
 Table Headings  Here
---------------- -----
-Sub   Headings  Too
 ===== ========= =====
-column spanning no
---------------- -----
-cell  cell      row
-column spanning spans
-=============== =====
+cell  cell      cell
+===== ========= =====

--- a/README.rst
+++ b/README.rst
@@ -34,9 +34,9 @@ Contributing
 ------------
 If you want to raise and issue or contribute code to PBjam, see the `guidelines on contributing <https://github.com/grd349/PBjam/blob/master/CONTRIBUTING.rst>`_.
 
-
 Authors
 -------
+There are different ways to contribute to PBjam, the Scientific Influencers help guide the scientific aspects of PBjam, the Chaos Engineers try to break the code or simply report bugs, while the Main Contributors submit Pull Requests with somewhat bigger additions to the code or documentation. 
 ===================================================== ================================================ ====================================================
 Main Contributors                                     Chaos Engineers                                  Scientific Influencers
 ===================================================== ================================================ ====================================================
@@ -55,5 +55,5 @@ Acknowledgements
 ----------------
 If you use PBjam in your work please cite the PBjam paper (forthcoming), and if possible provide links to the GitHub repository. 
 
-We encourage PBjam users to also cite the packages that PBjam makes use of. PBjam can list the publications that were used during a run (see the `Referencing Notebook <https://github.com/grd349/PBjam/tree/master/Examples/Example-references.ipynb>`_).
+We encourage PBjam users to also cite the packages and publications that PBjam makes use of. PBjam will automatically keep track of the publications that were used during a run, and can list them for you in bibtex format (see the `Referencing Notebook <https://github.com/grd349/PBjam/tree/master/Examples/Example-references.ipynb>`_).
 

--- a/README.rst
+++ b/README.rst
@@ -37,11 +37,13 @@ If you want to raise and issue or contribute code to PBjam, see the `guidelines 
 
 Authors
 -------
-=====  =====  ======
-  A      B    A or B
-=====  =====  ======
-`Lindsey Carboneau <https://github.com/lmcarboneau>`_  `Warrick Ball <https://github.com/warrickball>`_  Othman Benomar
-`Guy Davies <https://github.com/grd349>`_   `Joel Ong <https://github.com/darthoctopus>`_  Othman Benomar
-`Oliver Hall <https://github.com/ojhall94>`_  `Tanda Li <https://github.com/litanda>`_   Bill Chaplin
-True   True   True
-=====  =====  ======
+===== ========= =====
+Table Headings  Here
+--------------- -----
+Sub   Headings  Too
+===== ========= =====
+column spanning no
+--------------- -----
+cell  cell      row
+column spanning spans
+=============== =====

--- a/authors.csv
+++ b/authors.csv
@@ -1,0 +1,9 @@
+Main Contributors,Chaos Engineers,Scientific Oversight
+`Guy Davies <https://github.com/grd349>`_,`Warrick Ball <https://github.com/warrickball>`_,Othman Benomar
+`Oliver Hall <https://github.com/ojhall94>`_,`Joel Ong <https://github.com/darthoctopus>`_,Bill Chaplin
+`Alex Lyttle <https://github.com/alexlyttle>`_,`Tanda Li <https://github.com/litanda>`_,Enrico Corsaro
+`Martin Nielsen <https://github.com/nielsenmb>`_,`Rafa Garcia <https://github.com/rgarcibus>`_,Patrick Gaulme
+,,Mikkel Lund
+,,Benoit Mosser
+,,Andy Moya
+,,Ian Roxburgh

--- a/authors.csv
+++ b/authors.csv
@@ -1,4 +1,5 @@
 Main Contributors,Chaos Engineers,Scientific Oversight
+`Lindsey Carboneau <https://github.com/lmcarboneau>`_,,
 `Guy Davies <https://github.com/grd349>`_,`Warrick Ball <https://github.com/warrickball>`_,Othman Benomar
 `Oliver Hall <https://github.com/ojhall94>`_,`Joel Ong <https://github.com/darthoctopus>`_,Bill Chaplin
 `Alex Lyttle <https://github.com/alexlyttle>`_,`Tanda Li <https://github.com/litanda>`_,Enrico Corsaro

--- a/authors.csv
+++ b/authors.csv
@@ -1,4 +1,3 @@
-Main Contributors,Chaos Engineers,Scientific Oversight
 `Lindsey Carboneau <https://github.com/lmcarboneau>`_,,
 `Guy Davies <https://github.com/grd349>`_,`Warrick Ball <https://github.com/warrickball>`_,Othman Benomar
 `Oliver Hall <https://github.com/ojhall94>`_,`Joel Ong <https://github.com/darthoctopus>`_,Bill Chaplin

--- a/authors.csv
+++ b/authors.csv
@@ -1,8 +1,12 @@
-`Lindsey Carboneau <https://github.com/lmcarboneau>`_,,
-`Guy Davies <https://github.com/grd349>`_,`Warrick Ball <https://github.com/warrickball>`_,Othman Benomar
-`Oliver Hall <https://github.com/ojhall94>`_,`Joel Ong <https://github.com/darthoctopus>`_,Bill Chaplin
-`Alex Lyttle <https://github.com/alexlyttle>`_,`Tanda Li <https://github.com/litanda>`_,Enrico Corsaro
-`Martin Nielsen <https://github.com/nielsenmb>`_,`Rafa Garcia <https://github.com/rgarcibus>`_,Patrick Gaulme
+Main Contributors,Chaos Engineers,Scientific Oversight
+`Lindsey Carboneau <https://github.com/lmcarboneau>`_,`Warrick Ball <https://github.com/warrickball>`_,Othman Benomar
+`Guy Davies <https://github.com/grd349>`_,`Joel Ong <https://github.com/darthoctopus>`_,Othman Benomar
+`Oliver Hall <https://github.com/ojhall94>`_,`Tanda Li <https://github.com/litanda>`_,Bill Chaplin
+`Alex Lyttle <https://github.com/alexlyttle>`_,`Rafa Garcia <https://github.com/rgarcibus>`_,Enrico Corsaro
+`Martin Nielsen <https://github.com/nielsenmb>`_,,Patrick Gaulme
+,,Benoit Mosser
+,,Andy Moya
+,,Ian Roxburgh
 ,,Mikkel Lund
 ,,Benoit Mosser
 ,,Andy Moya

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -7,7 +7,7 @@ It's also possible to use the :class:`~pbjam.star.star` class to analyze single 
 
 Session
 -------
-The :class:`~pbjam.jar.session` class is the most straightforward way to analyze one or more stars with PBjam. The `Session notebook <example-session.ipynb>`_ provides a few simple examples of the forms of input that can be given to :class:`~pbjam.jar.session`. 
+The :class:`~pbjam.session.session` class is the most straightforward way to analyze one or more stars with PBjam. The `Session notebook <example-session.ipynb>`_ provides a few simple examples of the forms of input that can be given to :class:`~pbjam.session.session`. 
 
 .. note:: 
     The :class:`~pbjam.session.session` class is really just a fancy wrapper for the :class:`~pbjam.star.star` class. After initializing the session class, the instance can be called to execute the entire peakbagging procedure automatically.
@@ -15,7 +15,7 @@ The :class:`~pbjam.jar.session` class is the most straightforward way to analyze
 
 Star
 ----
-The :class:`Star <~pbjam.star.star>` class is meant for more detailed control of the inputs for each star. The `Star notebook <example-star.ipynb>`_ shows a simple example of this. 
+The :class:`~pbjam.star.star` class is meant for more detailed control of the inputs for each star. The `Star notebook <example-star.ipynb>`_ shows a simple example of this. 
     
 
 Advanced

--- a/pbjam/asy_peakbag.py
+++ b/pbjam/asy_peakbag.py
@@ -361,8 +361,8 @@ class asymptotic_fit(plotting, asymp_spec_model):
         Parameters
         ----------
         method : string
-            Method to be used for sampling the posterior. Options are 'mcmc' or
-            'nested. Default method is 'mcmc' that will call emcee, alternative
+            Method to be used for sampling the posterior. Options are 'emcee' or
+            'nested. Default method is 'emcee' that will call emcee, alternative
             is 'nested' to call nested sampling with CPnest.
         
         developer_mode : bool
@@ -379,18 +379,16 @@ class asymptotic_fit(plotting, asymp_spec_model):
         """
         self.developer_mode = developer_mode
         
-        if method not in ['mcmc', 'nested']:
+        if method not in ['emcee', 'nested']:
             warnings.warn(f'Method {method} not found: Using method mcmc')
-            method = 'mcmc'
+            method = 'emcee'
 
-        if method == 'mcmc':
+        if method == 'emcee':
             self.fit = pb.mcmc(np.median(self.start_samples, axis=0),
                                self.likelihood, self.prior)
             self.fit(start_samples=self.start_samples)
 
         elif method == 'nested':
-            #bounds = [[self.start_samples[:, n].min(), 
-            #           self.start_samples[:, n].max()] for n in range(len(self.par_names))]
             bounds = [[self.prior_data[key].min(), self.prior_data[key].max()] for key in self.par_names]
             self.fit = pb.nested(self.par_names, bounds, self.likelihood, self.prior, self.path)
             self.fit()

--- a/pbjam/asy_peakbag.py
+++ b/pbjam/asy_peakbag.py
@@ -362,8 +362,8 @@ class asymptotic_fit(plotting, asymp_spec_model):
         ----------
         method : string
             Method to be used for sampling the posterior. Options are 'emcee' or
-            'nested. Default method is 'emcee' that will call emcee, alternative
-            is 'nested' to call nested sampling with CPnest.
+            'cpnest. Default method is 'emcee' that will call emcee, alternative
+            is 'cpnest' to call nested sampling with CPnest.
         
         developer_mode : bool
             Run asy_peakbag in developer mode. Currently just retains the input 
@@ -379,8 +379,8 @@ class asymptotic_fit(plotting, asymp_spec_model):
         """
         self.developer_mode = developer_mode
         
-        if method not in ['emcee', 'nested']:
-            warnings.warn(f'Method {method} not found: Using method mcmc')
+        if method not in ['emcee', 'cpnest']:
+            warnings.warn(f'Method {method} not found: Using method emcee')
             method = 'emcee'
 
         if method == 'emcee':
@@ -388,7 +388,7 @@ class asymptotic_fit(plotting, asymp_spec_model):
                                self.likelihood, self.prior)
             self.fit(start_samples=self.start_samples)
 
-        elif method == 'nested':
+        elif method == 'cpnest':
             bounds = [[self.prior_data[key].min(), self.prior_data[key].max()] for key in self.par_names]
             self.fit = pb.nested(self.par_names, bounds, self.likelihood, self.prior, self.path)
             self.fit()

--- a/pbjam/data/pbjam_references.bib
+++ b/pbjam/data/pbjam_references.bib
@@ -1,12 +1,20 @@
 
-@book{python1995, 
+@article{cpnest, 
+    title={johnveitch/cpnest: Minor optimisation}, 
+    DOI={10.5281/zenodo.835874}, 
+    publisher={Zenodo}, 
+    author={{Veitch}, J. and {Del Pozzo}, W. and {Cody} and {Pitkin}, M. and {ed1d1a8d}}, 
+    year={2017}, 
+    month={Jul}}
+
+@book{python, 
   title={Python tutorial}, 
   author={Van Rossum, Guido and Drake Jr, Fred L}, 
   year={1995}, 
   publisher={Centrum voor Wiskunde en Informatica Amsterdam, The Netherlands} 
 }
 
-@book{Oliphant2006, 
+@book{numpy, 
   title={A guide to NumPy}, 
   author={Oliphant, Travis E}, 
   volume={1}, 
@@ -45,7 +53,169 @@ archivePrefix = {arXiv},
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-@MISC{2016zndo.....53155F,
+@ARTICLE{emcee,
+  author = {{Foreman-Mackey}, D. and {Hogg}, D.~W. and {Lang}, D. and {Goodman},
+	J. },
+  title = {{emcee: The MCMC Hammer}},
+  journal = {\pasp},
+  year = {2013},
+  volume = {125},
+  pages = {306-312},
+  month = mar,
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System},
+  adsurl = {http://adsabs.harvard.edu/abs/2013PASP..125..306F},
+  archiveprefix = {arXiv},
+  doi = {10.1086/670067},
+  eprint = {1202.3665},
+  keywords = {Data Analysis and Techniques},
+  primaryclass = {astro-ph.IM}
+}
+
+@ARTICLE{scipy,
+       author = {{Virtanen}, Pauli and {Gommers}, Ralf and {Oliphant},
+         Travis E. and {Haberland}, Matt and {Reddy}, Tyler and
+         {Cournapeau}, David and {Burovski}, Evgeni and {Peterson}, Pearu
+         and {Weckesser}, Warren and {Bright}, Jonathan and {van der Walt},
+         St{\'e}fan J.  and {Brett}, Matthew and {Wilson}, Joshua and
+         {Jarrod Millman}, K.  and {Mayorov}, Nikolay and {Nelson}, Andrew
+         R.~J. and {Jones}, Eric and {Kern}, Robert and {Larson}, Eric and
+         {Carey}, CJ and {Polat}, {\.I}lhan and {Feng}, Yu and {Moore},
+         Eric W. and {Vand erPlas}, Jake and {Laxalde}, Denis and
+         {Perktold}, Josef and {Cimrman}, Robert and {Henriksen}, Ian and
+         {Quintero}, E.~A. and {Harris}, Charles R and {Archibald}, Anne M.
+         and {Ribeiro}, Ant{\^o}nio H. and {Pedregosa}, Fabian and
+         {van Mulbregt}, Paul and {Contributors}, SciPy 1. 0},
+        title = "{SciPy 1.0: Fundamental Algorithms for Scientific
+                  Computing in Python}",
+      journal = {Nature Methods},
+      year = "2020",
+      volume={17},
+      pages={261--272},
+      adsurl = {https://rdcu.be/b08Wh},
+      doi = {https://doi.org/10.1038/s41592-019-0686-2},
+}
+
+@Article{matplotlib,
+  Author    = {Hunter, J. D.},
+  Title     = {Matplotlib: A 2D graphics environment},
+  Journal   = {Computing in Science \& Engineering},
+  Volume    = {9},
+  Number    = {3},
+  Pages     = {90--95},
+  abstract  = {Matplotlib is a 2D graphics package used for Python for
+  application development, interactive scripting, and publication-quality
+  image generation across user interfaces and operating systems.},
+  publisher = {IEEE COMPUTER SOC},
+  doi       = {10.1109/MCSE.2007.55},
+  year      = 2007
+}
+
+@article{pymc3,
+  doi = {10.7717/peerj-cs.55},
+  url = {https://doi.org/10.7717/peerj-cs.55},
+  year  = {2016},
+  month = {apr},
+  publisher = {{PeerJ}},
+  volume = {2},
+  pages = {e55},
+  author = {John Salvatier and Thomas V. Wiecki and Christopher Fonnesbeck},
+  title = {Probabilistic programming in Python using {PyMC}3},
+  journal = {{PeerJ} Computer Science}
+}
+
+@inproceedings{statsmodels,
+  title={statsmodels: Econometric and statistical modeling with python},
+  author={Seabold, Skipper and Perktold, Josef},
+  booktitle={9th Python in Science Conference},
+  year={2010},
+}
+
+@article{sklearn,
+ title={{Scikit-learn: Machine Learning in Python }},
+ author={Pedregosa, F. and Varoquaux, G. and Gramfort, A. and Michel, V.
+         and Thirion, B. and Grisel, O. and Blondel, M. and Prettenhofer, P.
+         and Weiss, R. and Dubourg, V. and Vanderplas, J. and Passos, A. and
+         Cournapeau, D. and Brucher, M. and Perrot, M. and Duchesnay, E.},
+ journal={Journal of Machine Learning Research},
+ volume={12},
+ pages={2825--2830},
+ year={2011}
+}
+
+
+@software{pandas,
+  author       = {Jeff Reback and
+                  Wes McKinney and
+                  jbrockmendel and
+                  Joris Van den Bossche and
+                  Tom Augspurger and
+                  Phillip Cloud and
+                  gfyoung and
+                  Sinhrks and
+                  Adam Klein and
+                  Matthew Roeschke and
+                  Jeff Tratner and
+                  Chang She and
+                  William Ayd and
+                  Simon Hawkins and
+                  Terji Petersen and
+                  Jeremy Schendel and
+                  Andy Hayden and
+                  Marc Garcia and
+                  Vytautas Jancauskas and
+                  MomIsBestFriend and
+                  Pietro Battiston and
+                  Skipper Seabold and
+                  chris-b1 and
+                  h-vetinari and
+                  Stephan Hoyer and
+                  Wouter Overmeire and
+                  alimcmaster1 and
+                  Mortada Mehyar and
+                  Christopher Whelan and
+                  Thomas Kluyver},
+  title        = {pandas-dev/pandas: Pandas 1.0.0},
+  month        = jan,
+  year         = 2020,
+  publisher    = {Zenodo},
+  version      = {v1.0.0},
+  doi          = {10.5281/zenodo.3630805},
+  url          = {https://doi.org/10.5281/zenodo.3630805}
+}
+
+@software{lightkurve,
+  author       = {Geert Barentsen and
+                  Christina Hedges and
+                  Zé Vinícius and
+                  Nicholas Saunders and
+                  gully and
+                  Oliver Hall and
+                  Keaton Bell and
+                  Sheila Sagear and
+                  Jose A Lerma III and
+                  Tom Barclay and
+                  KenMighell and
+                  Johnny Zhang and
+                  Guy Davies and
+                  Emma Turtelboom and
+                  Ann Marie Cody and
+                  Zach Berta-Thompson and
+                  Sam Lee and
+                  Peter Williams and
+                  Pal Szabo and
+                  Daniel and
+                  Brennan Vincello and
+                  Anand Sundaram},
+  title        = {KeplerGO/lightkurve: Lightkurve v1.5.0},
+  month        = nov,
+  year         = 2019,
+  publisher    = {Zenodo},
+  version      = {v1.5.0},
+  doi          = {10.5281/zenodo.3549023},
+  url          = {https://doi.org/10.5281/zenodo.3549023}
+}
+
+@MISC{corner,
        author = {{Foreman-Mackey}, Dan and {Vousden}, Will and {Price-Whelan}, Adrian and
          {Pitkin}, Matt and {Zabalza}, Victor and {Ryan}, Geoffrey and {Emily} and
          {Smith}, Michael and {Ashton}, Gregory and {Cruz}, Kelle and
@@ -62,33 +232,6 @@ archivePrefix = {arXiv},
        adsurl = {https://ui.adsabs.harvard.edu/abs/2016zndo.....53155F},
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
-
-@article{astropy2013,
-   author = {{Astropy Collaboration} and {Robitaille}, T.~P. and {Tollerud},
-             E.~J. and {Greenfield}, P. and {Droettboom}, M. and {Bray}, E. and
-             {Aldcroft}, T. and {Davis}, M. and {Ginsburg}, A. and
-             {Price-Whelan}, A.~M. and {Kerzendorf}, W.~E. and {Conley}, A. and
-             {Crighton}, N. and {Barbary}, K. and {Muna}, D. and {Ferguson}, H.
-             and {Grollier}, F. and {Parikh}, M.~M. and {Nair}, P.~H. and
-             {Unther}, H.~M. and {Deil}, C. and {Woillez}, J. and {Conseil}, S.
-             and {Kramer}, R. and {Turner}, J.~E.~H. and {Singer}, L. and
-             {Fox}, R. and {Weaver}, B.~A. and {Zabalza}, V. and {Edwards},
-             Z.~I. and {Azalee Bostroem}, K. and {Burke}, D.~J. and {Casey},
-             A.~R. and {Crawford}, S.~M. and {Dencheva}, N. and {Ely}, J. and
-             {Jenness}, T. and {Labrie}, K. and {Lim}, P.~L. and
-             {Pierfederici}, F. and {Pontzen}, A. and {Ptak}, A. and {Refsdal},
-             B. and {Servillat}, M. and {Streicher}, O.},
-    title = "{Astropy: A community Python package for astronomy}",
-  journal = {aap},
-     year = 2013,
-    month = oct,
-   volume = 558,
-    pages = {A33},
-      doi = {10.1051/0004-6361/201322068},
-   adsurl = {http://adsabs.harvard.edu/abs/2013A%26A...558A..33A},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
 
 @article{astropy2018,
    author = {{Astropy Collaboration} and {Price-Whelan}, A.~M. and

--- a/pbjam/data/pbjam_references.bib
+++ b/pbjam/data/pbjam_references.bib
@@ -1,4 +1,11 @@
 
+@book{python1995, 
+  title={Python tutorial}, 
+  author={Van Rossum, Guido and Drake Jr, Fred L}, 
+  year={1995}, 
+  publisher={Centrum voor Wiskunde en Informatica Amsterdam, The Netherlands} 
+}
+
 @book{Oliphant2006, 
   title={A guide to NumPy}, 
   author={Oliphant, Travis E}, 

--- a/pbjam/data/pbjam_references.bib
+++ b/pbjam/data/pbjam_references.bib
@@ -1,0 +1,142 @@
+
+@book{Oliphant2006, 
+  title={A guide to NumPy}, 
+  author={Oliphant, Travis E}, 
+  volume={1}, 
+  year={2006}, 
+  publisher={Trelgol Publishing USA} 
+}
+
+@ARTICLE{Evans2018,
+       author = {{Evans}, D.~W. and {Riello}, M. and {De Angeli}, F. and
+         {Carrasco}, J.~M. and {Montegriffo}, P. and {Fabricius}, C. and
+         {Jordi}, C. and {Palaversa}, L. and {Diener}, C. and {Busso}, G. and
+         {Cacciari}, C. and {van Leeuwen}, F. and {Burgess}, P.~W. and
+         {Davidson}, M. and {Harrison}, D.~L. and {Hodgkin}, S.~T. and
+         {Pancino}, E. and {Richards}, P.~J. and {Altavilla}, G. and
+         {Balaguer-N{\'u}{\~n}ez}, L. and {Barstow}, M.~A. and {Bellazzini}, M. and
+         {Brown}, A.~G.~A. and {Castellani}, M. and {Cocozza}, G. and
+         {De Luise}, F. and {Delgado}, A. and {Ducourant}, C. and {Galleti}, S. and
+         {Gilmore}, G. and {Giuffrida}, G. and {Holl}, B. and {Kewley}, A. and
+         {Koposov}, S.~E. and {Marinoni}, S. and {Marrese}, P.~M. and
+         {Osborne}, P.~J. and {Piersimoni}, A. and {Portell}, J. and
+         {Pulone}, L. and {Ragaini}, S. and {Sanna}, N. and {Terrett}, D. and
+         {Walton}, N.~A. and {Wevers}, T. and {Wyrzykowski}, {\L}.},
+        title = "{Gaia Data Release 2. Photometric content and validation}",
+      journal = {\aap},
+     keywords = {catalogs, surveys, instrumentation: photometers, techniques: photometric, galaxies: general, Astrophysics - Instrumentation and Methods for Astrophysics},
+         year = 2018,
+        month = aug,
+       volume = {616},
+          eid = {A4},
+        pages = {A4},
+          doi = {10.1051/0004-6361/201832756},
+archivePrefix = {arXiv},
+       eprint = {1804.09368},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2018A&A...616A...4E},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@MISC{2016zndo.....53155F,
+       author = {{Foreman-Mackey}, Dan and {Vousden}, Will and {Price-Whelan}, Adrian and
+         {Pitkin}, Matt and {Zabalza}, Victor and {Ryan}, Geoffrey and {Emily} and
+         {Smith}, Michael and {Ashton}, Gregory and {Cruz}, Kelle and
+         {Kerzendorf}, Wolfgang and {Caswell}, Thomas A and {Hoyer}, Stephan and
+         {Barbary}, Kyle and {Czekala}, Ian and {Rein}, Hanno and
+         {Gentry}, Eric and {Brewer}, Brendon J. and {Hogg}, David W.},
+        title = "{corner.py: corner.py v2.0.0}",
+         year = "2016",
+        month = "May",
+          eid = {10.5281/zenodo.53155},
+          doi = {10.5281/zenodo.53155},
+      version = {v2.0.0},
+    publisher = {Zenodo},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2016zndo.....53155F},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@article{astropy2013,
+   author = {{Astropy Collaboration} and {Robitaille}, T.~P. and {Tollerud},
+             E.~J. and {Greenfield}, P. and {Droettboom}, M. and {Bray}, E. and
+             {Aldcroft}, T. and {Davis}, M. and {Ginsburg}, A. and
+             {Price-Whelan}, A.~M. and {Kerzendorf}, W.~E. and {Conley}, A. and
+             {Crighton}, N. and {Barbary}, K. and {Muna}, D. and {Ferguson}, H.
+             and {Grollier}, F. and {Parikh}, M.~M. and {Nair}, P.~H. and
+             {Unther}, H.~M. and {Deil}, C. and {Woillez}, J. and {Conseil}, S.
+             and {Kramer}, R. and {Turner}, J.~E.~H. and {Singer}, L. and
+             {Fox}, R. and {Weaver}, B.~A. and {Zabalza}, V. and {Edwards},
+             Z.~I. and {Azalee Bostroem}, K. and {Burke}, D.~J. and {Casey},
+             A.~R. and {Crawford}, S.~M. and {Dencheva}, N. and {Ely}, J. and
+             {Jenness}, T. and {Labrie}, K. and {Lim}, P.~L. and
+             {Pierfederici}, F. and {Pontzen}, A. and {Ptak}, A. and {Refsdal},
+             B. and {Servillat}, M. and {Streicher}, O.},
+    title = "{Astropy: A community Python package for astronomy}",
+  journal = {aap},
+     year = 2013,
+    month = oct,
+   volume = 558,
+    pages = {A33},
+      doi = {10.1051/0004-6361/201322068},
+   adsurl = {http://adsabs.harvard.edu/abs/2013A%26A...558A..33A},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+
+@article{astropy2018,
+   author = {{Astropy Collaboration} and {Price-Whelan}, A.~M. and
+             {Sip{H o}cz}, B.~M. and {G{"u}nther}, H.~M. and {Lim}, P.~L. and
+             {Crawford}, S.~M. and {Conseil}, S. and {Shupe}, D.~L. and
+             {Craig}, M.~W. and {Dencheva}, N. and {Ginsburg}, A. and
+             {VanderPlas}, J.~T. and {Bradley}, L.~D. and
+             {P{'e}rez-Su{'a}rez}, D. and {de Val-Borro}, M.
+             and {Aldcroft}, T.~L. and {Cruz}, K.~L. and {Robitaille}, T.~P.
+             and {Tollerud}, E.~J. and {Ardelean}, C. and {Babej}, T. and
+             {Bach}, Y.~P. and {Bachetti}, M. and {Bakanov}, A.~V. and
+             {Bamford}, S.~P. and {Barentsen}, G. and {Barmby}, P. and
+             {Baumbach}, A. and {Berry}, K.~L.  and {Biscani}, F. and
+             {Boquien}, M. and {Bostroem}, K.~A. and {Bouma}, L.~G. and
+             {Brammer}, G.~B. and {Bray}, E.~M. and {Breytenbach}, H. and
+             {Buddelmeijer}, H. and {Burke}, D.~J. and {Calderone}, G. and
+             {Cano Rodr{'{i}}guez}, J.~L. and {Cara}, M. and {Cardoso},
+             J.~V.~M. and {Cheedella}, S. and {Copin}, Y. and {Corrales}, L.
+             and {Crichton}, D. and {D'Avella}, D. and {Deil}, C. and
+             {Depagne}, {'E}. and {Dietrich}, J.~P. and {Donath}, A. and
+             {Droettboom}, M. and {Earl}, N. and {Erben}, T. and {Fabbro}, S.
+             and {Ferreira}, L.~A. and {Finethy}, T. and {Fox}, R.~T. and
+             {Garrison}, L.~H. and {Gibbons}, S.~L.~J. and {Goldstein}, D.~A.
+             and {Gommers}, R. and {Greco}, J.~P. and {Greenfield}, P. and
+             {Groener}, A.~M. and {Grollier}, F. and {Hagen}, A. and {Hirst},
+             P. and {Homeier}, D. and {Horton}, A.~J. and {Hosseinzadeh}, G.
+             and {Hu}, L. and {Hunkeler}, J.~S. and {Ivezi{'c}}, {v Z}. and
+             {Jain}, A. and {Jenness}, T. and {Kanarek}, G. and {Kendrew}, S.
+             and {Kern}, N.~S. and {Kerzendorf}, W.~E. and {Khvalko}, A. and
+             {King}, J. and {Kirkby}, D. and {Kulkarni}, A.~M. and {Kumar}, A.
+             and {Lee}, A.  and {Lenz}, D.  and {Littlefair}, S.~P. and {Ma},
+             Z. and {Macleod}, D.~M. and {Mastropietro}, M. and {McCully}, C.
+             and {Montagnac}, S. and {Morris}, B.~M. and {Mueller}, M. and
+             {Mumford}, S.~J. and {Muna}, D. and {Murphy}, N.~A. and {Nelson},
+             S. and {Nguyen}, G.~H. and {Ninan}, J.~P. and {N{"o}the}, M. and
+             {Ogaz}, S. and {Oh}, S. and {Parejko}, J.~K.  and {Parley}, N. and
+             {Pascual}, S. and {Patil}, R. and {Patil}, A.~A.  and {Plunkett},
+             A.~L. and {Prochaska}, J.~X. and {Rastogi}, T. and {Reddy Janga},
+             V. and {Sabater}, J.  and {Sakurikar}, P. and {Seifert}, M. and
+             {Sherbert}, L.~E. and {Sherwood-Taylor}, H. and {Shih}, A.~Y. and
+             {Sick}, J. and {Silbiger}, M.~T. and {Singanamalla}, S. and
+             {Singer}, L.~P. and {Sladen}, P.~H. and {Sooley}, K.~A. and
+             {Sornarajah}, S. and {Streicher}, O. and {Teuben}, P. and
+             {Thomas}, S.~W. and {Tremblay}, G.~R. and {Turner}, J.~E.~H. and
+             {Terr{'o}n}, V.  and {van Kerkwijk}, M.~H. and {de la Vega}, A.
+             and {Watkins}, L.~L. and {Weaver}, B.~A. and {Whitmore}, J.~B. and
+             {Woillez}, J.  and {Zabalza}, V. and {Astropy Contributors}},
+    title = "{The Astropy Project: Building an Open-science Project and Status
+              of the v2.0 Core Package}",
+  journal = {aj},
+     year = 2018,
+    month = sep,
+   volume = 156,
+    pages = {123},
+      doi = {10.3847/1538-3881/aabc4f},
+   adsurl = {http://adsabs.harvard.edu/abs/2018AJ....156..123A},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}

--- a/pbjam/data/pbjam_references.bib
+++ b/pbjam/data/pbjam_references.bib
@@ -1,5 +1,5 @@
 
-@article{cpnest, 
+@article{nested, 
     title={johnveitch/cpnest: Minor optimisation}, 
     DOI={10.5281/zenodo.835874}, 
     publisher={Zenodo}, 
@@ -233,7 +233,7 @@ archivePrefix = {arXiv},
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-@article{astropy2018,
+@article{astropy,
    author = {{Astropy Collaboration} and {Price-Whelan}, A.~M. and
              {Sip{H o}cz}, B.~M. and {G{"u}nther}, H.~M. and {Lim}, P.~L. and
              {Crawford}, S.~M. and {Conseil}, S. and {Shupe}, D.~L. and

--- a/pbjam/data/pbjam_references.bib
+++ b/pbjam/data/pbjam_references.bib
@@ -95,7 +95,7 @@ archivePrefix = {arXiv},
       doi = {https://doi.org/10.1038/s41592-019-0686-2},
 }
 
-@Article{matplotlib,
+@ARTICLE{matplotlib,
   Author    = {Hunter, J. D.},
   Title     = {Matplotlib: A 2D graphics environment},
   Journal   = {Computing in Science \& Engineering},

--- a/pbjam/jar.py
+++ b/pbjam/jar.py
@@ -89,7 +89,7 @@ class references():
         with open(self.bibfile, 'r') as bib:
             bib = bib.read()
             
-            openers = ['@ARTICLE', '@article', 
+            openers = ['@ARTICLE', '@article', '@Article'
                        '@MISC', '@misc',
                        '@BOOK', '@book',
                        '@SOFTWARE', '@software',

--- a/pbjam/jar.py
+++ b/pbjam/jar.py
@@ -134,8 +134,11 @@ class references():
         ref : str
             Bib entry to add to the list
         """
-        
-        self._reflist.append(self.bibdict[ref])
+        if isinstance(ref, list):
+            for r in ref:
+                self._reflist.append(self.bibdict[r])
+        else:
+            self._reflist.append(self.bibdict[ref])
         
     def __call__(self, bibfile=None):
         """ Print the list of references used.

--- a/pbjam/jar.py
+++ b/pbjam/jar.py
@@ -7,7 +7,123 @@ This module contains general purpose functions that are used throughout PBjam.
 from . import PACKAGEDIR
 import os
 import numpy as np
+from scipy.special import erf
 
+
+
+class references():
+    """ A class for managing references used when running PBjam.
+
+    This is inherited by session and star. 
+    
+    """
+    
+    def __init__(self):
+        
+        self.bibfile = os.path.join(*[PACKAGEDIR, 'data', 'pbjam_references.bib'])
+        
+        self.reflist = []
+        
+        entries = np.unique(self._parseBibFile())
+
+        self.bibdict = {}
+        for i, block in enumerate(entries):
+            key = block[block.index('{')+1:block.index(',')]
+            self.bibdict[key] = block
+            
+    def _findBlockEnd(self, string, idx):
+        """ Find block of {}
+        
+        Go through string starting at idx, and find
+        the index corresponding to the curly bracket
+        that closes the opening curly bracket.
+        
+        So { will be closed by } even if there are more
+        curly brackets in between.
+        
+        Note
+        ----
+        This also works in reverse, so opening with }
+        will be closed by {.
+        
+        """
+        
+        a = 0
+        for i, char in enumerate(string[idx:]):
+            if char == '{':
+                a -= 1
+            elif char == '}':
+                a += 1
+                
+            if (i >= len(string[idx:])-1) and (a != 0):    
+                print('Warning: Reached end of bibtex file with no closing curly bracket. Your .bib file may be formatted incorrectly. The reference list may be garbled.')
+            if a ==0:
+                break  
+        
+        if string[idx+i] == '{':
+            print('Warning: Ended on an opening bracket. Your .bib file may be formatted incorrectly.')
+            
+        return idx+i
+        
+    def _parseBibFile(self):
+        """ Put contents of a bibtex file into a dictionary.
+        
+        Article shorthand names (e.g., @Article{shorthand_name) becomes the
+        dictionary key.
+        
+        """
+        
+        with open(self.bibfile, 'r') as bib:
+            bib = bib.read()
+            
+            openers = ['@ARTICLE', '@article', 
+                       '@MISC', '@misc',
+                       '@BOOK', '@book'] #Update this if other types of entries are added to the bib file.
+            
+            blocks = []   
+            safety = 0
+            while any([x in bib for x in openers]):
+                for opener in openers:
+                    try:
+                        start = bib.index(opener)
+        
+                        end = self._findBlockEnd(bib, start+len(opener))
+         
+                        blocks.append([bib[start:end+1]])
+        
+                        bib = bib[:start] + bib[end+1:]
+                            
+                    except:
+                        pass
+                    safety += 1
+                    
+                    if safety > 1000:
+                        break
+                
+            return blocks
+            
+    def _addRef(self, ref):
+        """ Add reference from bibdict to active list
+        
+        Remember to add the relevant references to the bibfile
+        
+        """
+        
+        self.reflist.append(self.bibdict[ref])
+        
+    def __call__(self, to_file=False):
+        """ Print the list of references used.
+        
+        """
+        
+        out = '\n\n'.join(np.unique(self.reflist))
+        print('References used in this run.')
+        print(out)
+        
+        if to_file:
+            with open('pbjam.bib', mode='w') as file_object: #robustify the filepath so it goes to the right place all the time.
+                print(out, file=file_object)
+            
 def get_priorpath():
     """ Get default prior path name
     
@@ -21,7 +137,7 @@ def get_priorpath():
     return os.path.join(*[PACKAGEDIR, 'data', 'prior_data.csv'])
 
 
-def get_percentiles(X, sigma = 2, **kwargs):
+def get_percentiles(X, nsigma = 2, **kwargs):
     """ Get percentiles of an distribution
     
     Compute the percentiles corresponding to sigma=1,2,3.. including the 
@@ -43,18 +159,12 @@ def get_percentiles(X, sigma = 2, **kwargs):
         Numpy array of percentile values of X.
     
     """
+
+    a = np.array([0.5*(1+erf(z/np.sqrt(2))) for z in range(nsigma)])
     
-    percs = np.array([0.682689492137,
-                      0.954499736104,
-                      0.997300203937,
-                      0.999936657516,
-                      0.999999426697,
-                      0.999999998027])*100/2    
-    percs = np.append(0, percs)    
-    percs = np.append(-percs[::-1][:-1],percs)
-    percs += 50
-    
-    return np.percentile(X, percs[6-sigma : 6+sigma+1], **kwargs)
+    percs = np.append((1-a[::-1][:-1]),a)*100
+
+    return np.percentile(X, percs, **kwargs)
 
 
 def to_log10(x, xerr):

--- a/pbjam/jar.py
+++ b/pbjam/jar.py
@@ -112,6 +112,8 @@ class references():
                     
                     if safety > 1000:
                         break
+                    
+            bibitems = np.unique(bibitems)
             
             bibdict = {}
             for i, item in enumerate(bibitems):
@@ -186,7 +188,7 @@ def get_percentiles(X, nsigma = 2, **kwargs):
     
     """
 
-    a = np.array([0.5*(1+erf(z/np.sqrt(2))) for z in range(nsigma)])
+    a = np.array([0.5*(1+erf(z/np.sqrt(2))) for z in range(nsigma+1)])
     
     percs = np.append((1-a[::-1][:-1]),a)*100
 

--- a/pbjam/jar.py
+++ b/pbjam/jar.py
@@ -91,7 +91,9 @@ class references():
             
             openers = ['@ARTICLE', '@article', 
                        '@MISC', '@misc',
-                       '@BOOK', '@book'] #Update this if other types of entries are added to the bib file.
+                       '@BOOK', '@book',
+                       '@SOFTWARE', '@software',
+                       '@INPROCEEDINGS', '@inproceedings'] #Update this if other types of entries are added to the bib file.
             
             bibitems = []   
             safety = 0

--- a/pbjam/jar.py
+++ b/pbjam/jar.py
@@ -22,7 +22,7 @@ class references():
         
         self.bibfile = os.path.join(*[PACKAGEDIR, 'data', 'pbjam_references.bib'])
         
-        self.reflist = []
+        self._reflist = []
         
         entries = np.unique(self._parseBibFile())
 
@@ -109,21 +109,21 @@ class references():
         
         """
         
-        self.reflist.append(self.bibdict[ref])
+        self._reflist.append(self.bibdict[ref])
         
     def __call__(self, to_file=False):
         """ Print the list of references used.
         
         """
         
-        out = '\n\n'.join(np.unique(self.reflist))
+        out = '\n\n'.join(np.unique(self._reflist))
         print('References used in this run.')
         print(out)
         
         if to_file:
             with open('pbjam.bib', mode='w') as file_object: #robustify the filepath so it goes to the right place all the time.
                 print(out, file=file_object)
-            
+                            
 def get_priorpath():
     """ Get default prior path name
     

--- a/pbjam/peakbag.py
+++ b/pbjam/peakbag.py
@@ -75,6 +75,8 @@ class peakbag(plotting):
             self.trim_ladder(verbose=verbose)
         self.gp0 = [] # Used for gp linewidth info.
 
+        starinst.references._addRef('pymc3')
+        
         starinst.peakbag = self
 
 

--- a/pbjam/peakbag.py
+++ b/pbjam/peakbag.py
@@ -317,6 +317,28 @@ class peakbag(plotting):
             pm.Gamma('yobs', alpha=1, beta=1.0/limit, observed=self.ladder_s)
 
 
+    def _addPPRatio(self):
+        """ Add the prior/posterior width ratio to summary
+        
+        Computes the ratio of the prior width and the posterior width. This is a
+        quantity which indicates which probability predominantly informs the 
+        resulting mode frequency. If the ratio is < 1 the prior dominates, and
+        vice versa for ratios > 1. 
+        
+        No cut-off is made based on this ratio, it is merely to inform the user.
+                
+        """
+        
+        dnu = 10**self.asy_fit.summary.loc['dnu', 'mean']
+        
+        log_ppr = np.log10((0.03*dnu))-np.log10(self.summary['sd'])
+        
+        idx = np.array(['l' in name for name in self.summary.index], dtype = 'bool')
+        
+        self.summary['log_ppr'] = np.nan
+        
+        self.summary.at[idx, 'log_ppr'] = log_ppr[idx]
+
 
     def __call__(self, model_type='simple', tune=1500, nthreads=1, maxiter=4,
                      advi=False):
@@ -384,7 +406,7 @@ class peakbag(plotting):
             self.summary = pm.summary(self.traces)
         except:
             self.summary = pm.stats.summary(self.traces)
-                   
+        
         self.par_names = self.summary.index
         
         samps = np.array([self.traces[x] for x in self.traces.varnames if not x.endswith('_log__')])

--- a/pbjam/priors.py
+++ b/pbjam/priors.py
@@ -61,6 +61,8 @@ class kde(plotting):
             self.pg = starinst.pg
             self._obs = starinst._obs
             self._log_obs = starinst._log_obs
+            starinst.references._addRef(['statsmodels', 'pandas', 'emcee', 
+                                         'numpy'])
             starinst.kde = self
 
         if prior_file:

--- a/pbjam/priors.py
+++ b/pbjam/priors.py
@@ -1,7 +1,8 @@
 """
 
-The priors module contains the `KDE' class, which is used to construct the prior
-for `asy_peakbag' as well as providing the initial starting location .
+The priors module contains the :class:`~pbjam.priors.kde` class, which is used 
+to construct the prior for `asy_peakbag' as well as providing the initial 
+starting location .
 
 """
 

--- a/pbjam/session.py
+++ b/pbjam/session.py
@@ -536,7 +536,8 @@ class session():
 
         self.stars = []
         self.references = references()
-        self.references._addRef('python1995')
+        self.references._addRef(['python', 'pandas', 'numpy', 'astropy', 
+                                 'lightkurve'])
         
         if isinstance(dictlike, (dict, np.recarray, pd.DataFrame, str)):
             if isinstance(dictlike, str):

--- a/pbjam/session.py
+++ b/pbjam/session.py
@@ -52,6 +52,8 @@ import pandas as pd
 import os, pickle, warnings
 from .star import star, _format_name
 from datetime import datetime
+from .jar import references
+
 
 def _organize_sess_dataframe(vardf):
     """ Takes input dataframe and tidies it up.
@@ -533,6 +535,8 @@ class session():
                  quarter=None, mission=None, path=None, download_dir=None):
 
         self.stars = []
+        self.references = references()
+        self.references._addRef('python1995')
         
         if isinstance(dictlike, (dict, np.recarray, pd.DataFrame, str)):
             if isinstance(dictlike, str):
@@ -582,7 +586,7 @@ class session():
                                    teff=vardf.loc[i, ['teff', 'teff_err']].values,
                                    bp_rp=vardf.loc[i, ['bp_rp', 'bp_rp_err']].values,
                                    path=path))
-
+            
         for i, st in enumerate(self.stars):
             if st.numax[0] > st.f[-1]:
                 warnings.warn("Input numax is greater than Nyquist frequeny for %s" % (st.ID))
@@ -636,7 +640,9 @@ class session():
                    store_chains=store_chains, nthreads=nthreads, 
                    asy_sampling=asy_sampling, developer_mode=developer_mode)
                 
-                self.stars[i] = None
+                self.references._reflist += st.references._reflist
+                
+                #self.stars[i] = None
             
             # Crude way to send error messages that occur in star up to Session 
             # without ending the session. Is there a better way?

--- a/pbjam/session.py
+++ b/pbjam/session.py
@@ -642,7 +642,7 @@ class session():
                 
                 self.references._reflist += st.references._reflist
                 
-                #self.stars[i] = None
+                self.stars[i] = None
             
             # Crude way to send error messages that occur in star up to Session 
             # without ending the session. Is there a better way?

--- a/pbjam/session.py
+++ b/pbjam/session.py
@@ -594,7 +594,7 @@ class session():
 
     def __call__(self, bw_fac=1, norders=8, model_type='simple', tune=1500, 
                  nthreads=1, verbose=False, make_plots=False, store_chains=False, 
-                 asy_sampling='mcmc', developer_mode=False):
+                 asy_sampling='emcee', developer_mode=False):
         """ Call all the star class instances
 
         Once initialized, calling the session class instance will loop through
@@ -624,7 +624,7 @@ class session():
             Whether or not to store MCMC chains on disk. Default is False.
         asy_sampling : str, optional.
             Which type of sampler to use for the asymptotic peakbagging. The 
-            options are 'mcmc' and 'cpnest'. Default is 'mcmc'.
+            options are 'emcee' and 'cpnest'. Default is 'emcee'.
         developer_mode : bool
             Run asy_peakbag in developer mode. Currently just retains the input 
             value of dnu and numax as priors, for the purposes of expanding

--- a/pbjam/star.py
+++ b/pbjam/star.py
@@ -89,9 +89,7 @@ class star(plotting):
         self.dnu = dnu
 
         self.references = references()
-        self.references._addRef('numpy')
-        self.references._addRef('python')
-        self.references._addRef('lightkurve')
+        self.references._addRef(['numpy', 'python', 'lightkurve', 'astropy'])
         
         teff, bp_rp = self._checkTeffBpRp(teff, bp_rp)
         self.teff = teff
@@ -155,8 +153,7 @@ class star(plotting):
         elif not bprp_good:
             bp_rp = [1.2927, 0.5] # these are rough esimates from the prior
             
-        self.references._addRef('Evans2018')
-        self.references._addRef('astropy')
+        self.references._addRef(['Evans2018'])
         
         return teff, bp_rp
 
@@ -262,16 +259,16 @@ class star(plotting):
                                    savefig=make_plots)
             self.kde.plot_echelle(path=self.path, ID=self.ID,
                                   savefig=make_plots)
+            
+            self.references._addRef('matplotlib')
 
         if store_chains:
             kde_samps = pd.DataFrame(self.kde.samples, columns=self.kde.par_names)
             kde_samps.to_csv(self._get_outpath(f'kde_chains_{self.ID}.csv'), index=False)
             
-        self.references._addRef('pandas')
-
 
     def run_asy_peakbag(self, norders, make_plots=False,
-                        store_chains=False, method='mcmc', 
+                        store_chains=False, method='emcee', 
                         developer_mode=False):
         """ Run all steps involving asy_peakbag.
 
@@ -304,6 +301,7 @@ class star(plotting):
 
         # Call
         self.asy_fit(method, developer_mode)
+        self.references._addRef(method)
 
         # Store
         self.asy_fit.summary.to_csv(self._get_outpath(f'asymptotic_fit_summary_{self.ID}.csv'),
@@ -317,12 +315,11 @@ class star(plotting):
                                      savefig=make_plots)
             self.asy_fit.plot_echelle(path=self.path, ID=self.ID,
                                       savefig=make_plots)
-            
+            self.references._addRef('matplotlib')
+
         if store_chains:
             asy_samps = pd.DataFrame(self.asy_fit.samples, columns=self.asy_fit.par_names)
             asy_samps.to_csv(self._get_outpath(f'asymptotic_fit_chains_{self.ID}.csv'), index=False)
-
-        self.references._addRef('pandas')
 
     
     def run_peakbag(self, model_type='simple', tune=1500, nthreads=1,
@@ -364,13 +361,12 @@ class star(plotting):
                                        savefig=make_plots)
             self.peakbag.plot_echelle(path=self.path, ID=self.ID, 
                                       savefig=make_plots)
+            self.references._addRef('matplotlib')
 
         if store_chains:
             peakbag_samps = pd.DataFrame(self.peakbag.samples, columns=self.peakbag.par_names)
             peakbag_samps.to_csv(self._get_outpath(f'peakbag_chains_{self.ID}.csv'), index=False)
             
-        self.references._addRef('pandas')
-
 
     def __call__(self, bw_fac=1.0, norders=8, model_type='simple', tune=1500,
                  nthreads=1, make_plots=True, store_chains=False, 

--- a/pbjam/star.py
+++ b/pbjam/star.py
@@ -18,7 +18,7 @@ import os, warnings, re, time, numbers
 from .asy_peakbag import asymptotic_fit
 from .priors import kde
 from .peakbag import peakbag
-from .jar import get_priorpath, to_log10
+from .jar import get_priorpath, to_log10, references
 from .plotting import plotting
 import pandas as pd
 import numpy as np
@@ -92,6 +92,9 @@ class star(plotting):
         self.numax = numax
         self.dnu = dnu
 
+        self.references = references()
+        self.references._addRef('Oliphant2006')
+
         teff, bp_rp = self._checkTeffBpRp(teff, bp_rp)
         self.teff = teff
         self.bp_rp = bp_rp
@@ -110,8 +113,10 @@ class star(plotting):
             self.prior_file = get_priorpath()
         else:
             self.prior_file = prior_file
+            
 
     def _checkTeffBpRp(self, teff, bp_rp):
+        self.references._addRef('Evans2018')
         # Teff and Gbp-Grp provide a lot of the same information, so only one of
         # them need to be provided to start with. If one is not provided, PBjam
         # will assume a wide prior on it.

--- a/pbjam/star.py
+++ b/pbjam/star.py
@@ -284,9 +284,9 @@ class star(plotting):
         store_chains : bool, optional
             Whether or not to store posterior samples on disk. Default is False.
         method : string
-            Method to be used for sampling the posterior. Options are 'mcmc' or
-            'nested. Default method is 'mcmc' that will call emcee, alternative
-            is 'nested' to call nested sampling with CPnest.
+            Method to be used for sampling the posterior. Options are 'emcee' or
+            'cpnest. Default method is 'emcee' that will call emcee, alternative
+            is 'cpnest' to call nested sampling with CPnest.
         developer_mode : bool
             Run asy_peakbag in developer mode. Currently just retains the input 
             value of dnu and numax as priors, for the purposes of expanding
@@ -370,7 +370,7 @@ class star(plotting):
 
     def __call__(self, bw_fac=1.0, norders=8, model_type='simple', tune=1500,
                  nthreads=1, make_plots=True, store_chains=False, 
-                 asy_sampling='mcmc', developer_mode=False):
+                 asy_sampling='emcee', developer_mode=False):
         """ Perform all the PBjam steps
 
         Starts by running KDE, followed by Asy_peakbag and then finally peakbag.
@@ -396,8 +396,8 @@ class star(plotting):
             Whether or not to store posterior samples on disk. Default is False.
         asy_sampling : string
             Method to be used for sampling the posterior in asy_peakbag. Options
-            are 'mcmc' or 'nested. Default method is 'mcmc' that will call 
-            emcee, alternative is 'nested' to call nested sampling with CPnest.
+            are 'emcee' or 'cpnest. Default method is 'emcee' that will call 
+            emcee, alternative is 'cpnest' to call nested sampling with CPnest.
         developer_mode : bool
             Run asy_peakbag in developer mode. Currently just retains the input 
             value of dnu and numax as priors, for the purposes of expanding

--- a/pbjam/tests/test_jar.py
+++ b/pbjam/tests/test_jar.py
@@ -61,7 +61,7 @@ def test_get_percentiles():
     
     # setup
     func = get_percentiles
-    inp = [np.random.normal(0,1, size = 10), 3]
+    inp = [np.random.normal(size = 100), 3]
     print(func(*inp))
 
     #print(func(*inp)[])
@@ -73,7 +73,7 @@ def test_get_percentiles():
     pbt.right_shape(func, inp, (2*inp[1]+1,))
     
     # check some different inputs
-    inp = [np.random.normal(0,1, size = 30000), 5]
+    inp = [np.random.normal(size = 30000), 4]
     pbt.right_shape(func, inp, (2*inp[1]+1,))
     
     inp = [[0,0,0,1,1], 1]

--- a/pbjam/tests/test_jar.py
+++ b/pbjam/tests/test_jar.py
@@ -62,7 +62,8 @@ def test_get_percentiles():
     # setup
     func = get_percentiles
     inp = [np.random.normal(0,1, size = 10), 3]
-    
+    print(func(*inp))
+
     #print(func(*inp)[])
     
     # simple tests


### PR DESCRIPTION
You can now get a list of references from session or star using the reference() method.
```
sess = session('catname', ....)
sess.references()
```

The list is updated based on what modules are run. So the star reference list won't show CPnest if you only use EMCEE in asy_peakbag for example, or similarly won't show pymc3 if you don't use the peakbag module.

If new modules are added to PBjam, you can add the references by using the _addRef() method
```
star.references._addRef('JoeSmith2020') 
```

References that are not Python related, e.g., Gaia Collaboration are also shown. 

This should be added where relevant (I haven't really come up with a good system yet). The _addRef method does require access the star class instance though. It might be possible to come up with a better way, so functions/classes that don't really know about the star class instance (helper functions) can still add to the list.

If new references are added, add the relevant BibTeX block to pbjam/data/pbjam_references.bib, just like you would in a LaTeX doc.