### PR TITLE
Add a useful error message if we don't pass either ID or dictlike to session.__init__

### DIFF
--- a/pbjam/session.py
+++ b/pbjam/session.py
@@ -562,6 +562,8 @@ class session():
             
             _format_col(vardf, timeseries, 'timeseries')
             _format_col(vardf, spectrum, 'spectrum')
+        else:
+            raise TypeError('session.__init__ requires either ID or dictlike')
 
         for i in vardf.index:
             


### PR DESCRIPTION
The following snippet
````Python
import numpy as np
import pbjam

t = np.arange(1000.)
y = np.sin(t/10.)
s = pbjam.session(timeseries=[t, y],
                  numax=(240.0, 10.0), dnu=(20.0, 0.2),
                  teff=(5000, 100), bp_rp=(1.0, 0.02))
````
produces the error
````
Checkpoint exception raise
/home/wball/.local/lib/python3.7/site-packages/statsmodels/tools/_testing.py:19: FutureWarning: pandas.util.testing is deprecated. Use the functions in the public API at pandas.testing instead.
  import pandas.util.testing as tm
Traceback (most recent call last):
  File "tsOut_error.py", line 8, in <module>
    teff=(5000, 100), bp_rp=(1.0, 0.02))
  File "/home/wball/pypi/PBjam/pbjam/session.py", line 567, in __init__
    for i in vardf.index:
UnboundLocalError: local variable 'vardf' referenced before assignment
````
The actual problem is that `session.__init__` needs either the `ID` or `dictlike` keyword arguments, so this PR catches when both are missing and produces a more useful error message.