### PR TITLE
WIP: Implement logging

### DIFF
--- a/pbjam/__init__.py
+++ b/pbjam/__init__.py
@@ -6,8 +6,17 @@ PACKAGEDIR = os.path.abspath(os.path.dirname(__file__))
 
 import logging
 _logger = logging.getLogger(__name__)
-_logger.addHandler(logging.StreamHandler())
-# TODO: format stream handler if need be.
+_logger.setLevel('DEBUG')
+
+# if len(_logger.handlers) == 0:
+# Don't add a stream handler if any handler already exists, i.e. user knows what they're doing
+_handler = logging.StreamHandler()
+_FMT = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s: %(message)s', datefmt='%Y-%m-%d, %H:%M:%S',)
+_handler.setFormatter(_FMT)
+_handler.setLevel('INFO')
+_logger.addHandler(_handler)
+
+_logger.info('Importing PBjam')
 
 from .version import __version__
 from .priors import kde

--- a/pbjam/__init__.py
+++ b/pbjam/__init__.py
@@ -5,20 +5,20 @@ import os
 PACKAGEDIR = os.path.abspath(os.path.dirname(__file__))
 
 import logging
-HANDLER_FMT = logging.Formatter("%(asctime)-15s : %(levelname)-8s : %(name)-17s : %(message)s")
+from .config import stdout_handler, stderr_handler
 
+# Setup global pbjam logger
 logger = logging.getLogger(__name__)
-logger.setLevel('DEBUG')
+logger.setLevel('DEBUG')  # <--- minimum possible level for global pbjam logger
 
-# Add a stream handler at level=='INFO' - should we do this?
-_stream_handler = logging.StreamHandler()
-_stream_handler.setFormatter(HANDLER_FMT)
-_stream_handler.setLevel('INFO')
+logger.addHandler(stdout_handler())
+logger.addHandler(stderr_handler())
 
-logger.addHandler(_stream_handler)
-logger.debug('Importing PBjam')
+logger.debug(f'Initializing {__name__}')
 
 from .version import __version__
+logger.debug(f'version == {__version__}')
+
 from .priors import kde
 from .session import session
 from .asy_peakbag import asymp_spec_model, asymptotic_fit
@@ -27,3 +27,5 @@ from .ellone import ellone
 from .star import star
 from .mcmc import mcmc
 from .mcmc import nested
+
+logger.debug(f'Initialized {__name__}')

--- a/pbjam/__init__.py
+++ b/pbjam/__init__.py
@@ -5,18 +5,18 @@ import os
 PACKAGEDIR = os.path.abspath(os.path.dirname(__file__))
 
 import logging
-_logger = logging.getLogger(__name__)
-_logger.setLevel('DEBUG')
+HANDLER_FMT = logging.Formatter("%(asctime)-15s : %(levelname)-8s : %(name)-17s : %(message)s")
 
-# if len(_logger.handlers) == 0:
-# Don't add a stream handler if any handler already exists, i.e. user knows what they're doing
-_handler = logging.StreamHandler()
-_FMT = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s: %(message)s', datefmt='%Y-%m-%d, %H:%M:%S',)
-_handler.setFormatter(_FMT)
-_handler.setLevel('INFO')
-_logger.addHandler(_handler)
+logger = logging.getLogger(__name__)
+logger.setLevel('DEBUG')
 
-_logger.info('Importing PBjam')
+# Add a stream handler at level=='INFO' - should we do this?
+_stream_handler = logging.StreamHandler()
+_stream_handler.setFormatter(HANDLER_FMT)
+_stream_handler.setLevel('INFO')
+
+logger.addHandler(_stream_handler)
+logger.debug('Importing PBjam')
 
 from .version import __version__
 from .priors import kde

--- a/pbjam/__init__.py
+++ b/pbjam/__init__.py
@@ -5,14 +5,16 @@ import os
 PACKAGEDIR = os.path.abspath(os.path.dirname(__file__))
 
 import logging
-from .config import stdout_handler, stderr_handler
+# from .config import stdout_handler, stderr_handler
+from .config import console_handler
 
 # Setup global pbjam logger
 logger = logging.getLogger(__name__)
 logger.setLevel('DEBUG')  # <--- minimum possible level for global pbjam logger
 
-logger.addHandler(stdout_handler())
-logger.addHandler(stderr_handler())
+# logger.addHandler(stdout_handler())
+# logger.addHandler(stderr_handler())
+logger.addHandler(console_handler())
 
 logger.debug(f'Initializing {__name__}')
 

--- a/pbjam/__init__.py
+++ b/pbjam/__init__.py
@@ -5,7 +5,6 @@ import os
 PACKAGEDIR = os.path.abspath(os.path.dirname(__file__))
 
 import logging
-
 _logger = logging.getLogger(__name__)
 # TODO: add stream handler if need be
 

--- a/pbjam/__init__.py
+++ b/pbjam/__init__.py
@@ -4,6 +4,11 @@
 import os
 PACKAGEDIR = os.path.abspath(os.path.dirname(__file__))
 
+import logging
+
+_logger = logging.getLogger(__name__)
+# TODO: add stream handler if need be
+
 from .version import __version__
 from .priors import kde
 from .session import session

--- a/pbjam/__init__.py
+++ b/pbjam/__init__.py
@@ -6,7 +6,8 @@ PACKAGEDIR = os.path.abspath(os.path.dirname(__file__))
 
 import logging
 _logger = logging.getLogger(__name__)
-# TODO: add stream handler if need be
+_logger.addHandler(logging.StreamHandler())
+# TODO: format stream handler if need be.
 
 from .version import __version__
 from .priors import kde

--- a/pbjam/config.py
+++ b/pbjam/config.py
@@ -1,0 +1,23 @@
+# Configures the pbjam package upon import
+import logging, sys
+
+HANDLER_FMT = logging.Formatter("%(asctime)-15s : %(levelname)-8s : %(name)-17s : %(message)s")
+
+
+class info_filter(logging.Filter):
+    def filter(self, rec):
+        return rec.levelno == logging.INFO
+
+
+class stdout_handler(logging.StreamHandler):
+    def __init__(self):
+        super().__init__(stream=sys.stdout)
+        self.setFormatter(HANDLER_FMT)
+        self.addFilter(info_filter())
+
+
+class stderr_handler(logging.StreamHandler):
+    def __init__(self):
+        super().__init__(stream=sys.stderr)
+        self.setFormatter(HANDLER_FMT)
+        self.setLevel('WARNING')

--- a/pbjam/config.py
+++ b/pbjam/config.py
@@ -4,20 +4,26 @@ import logging, sys
 HANDLER_FMT = logging.Formatter("%(asctime)-15s : %(levelname)-8s : %(name)-17s : %(message)s")
 
 
-class info_filter(logging.Filter):
-    def filter(self, rec):
-        return rec.levelno == logging.INFO
+# class info_filter(logging.Filter):
+#     def filter(self, rec):
+#         return rec.levelno == logging.INFO
 
 
-class stdout_handler(logging.StreamHandler):
+# class stdout_handler(logging.StreamHandler):
+#     def __init__(self):
+#         super().__init__(stream=sys.stdout)
+#         self.setFormatter(HANDLER_FMT)
+#         self.addFilter(info_filter())
+
+
+# class stderr_handler(logging.StreamHandler):
+#     def __init__(self):
+#         super().__init__(stream=sys.stderr)
+#         self.setFormatter(HANDLER_FMT)
+#         self.setLevel('WARNING')
+
+class console_handler(logging.StreamHandler):
     def __init__(self):
-        super().__init__(stream=sys.stdout)
+        super().__init__()
         self.setFormatter(HANDLER_FMT)
-        self.addFilter(info_filter())
-
-
-class stderr_handler(logging.StreamHandler):
-    def __init__(self):
-        super().__init__(stream=sys.stderr)
-        self.setFormatter(HANDLER_FMT)
-        self.setLevel('WARNING')
+        self.setLevel('INFO')

--- a/pbjam/plotting.py
+++ b/pbjam/plotting.py
@@ -13,7 +13,13 @@ import numpy as np
 import astropy.units as u
 import pandas as pd
 
-class plotting():
+from .jar import log
+
+_logger = logging.getLogger(__name__)  # For module-level logging
+_logger.debug('Initialized module logger.')
+
+
+class plotting:
     """ Class inherited by PBjam modules to plot results
     
     This is used to standardize the plots produced at various steps of the 
@@ -24,7 +30,7 @@ class plotting():
     called from. 
     
     """
-    
+    @log(_logger)
     def __init__(self):
         pass
 
@@ -52,7 +58,8 @@ class plotting():
         if path and ID:
             outpath = os.path.join(*[path,  type(self).__name__+f'_{figtype}_{str(ID)}.png'])
             fig.savefig(outpath)
-
+    
+    @log(_logger)
     def plot_echelle(self, pg=None, path=None, ID=None, savefig=False):
         """ Make echelle plot
 

--- a/pbjam/plotting.py
+++ b/pbjam/plotting.py
@@ -15,8 +15,8 @@ import pandas as pd
 
 from .jar import log
 
-_logger = logging.getLogger(__name__)  # For module-level logging
-_logger.debug('Initialized module logger.')
+logger = logging.getLogger(__name__)  # For module-level logging
+logger.debug('Initialized module logger.')
 
 
 class plotting:
@@ -30,7 +30,7 @@ class plotting:
     called from. 
     
     """
-    @log(_logger)
+    @log(logger)
     def __init__(self):
         pass
 
@@ -59,7 +59,7 @@ class plotting:
             outpath = os.path.join(*[path,  type(self).__name__+f'_{figtype}_{str(ID)}.png'])
             fig.savefig(outpath)
     
-    @log(_logger)
+    @log(logger)
     def plot_echelle(self, pg=None, path=None, ID=None, savefig=False):
         """ Make echelle plot
 

--- a/pbjam/session.py
+++ b/pbjam/session.py
@@ -52,8 +52,10 @@ import pandas as pd
 import os, pickle, warnings
 from .star import star, _format_name
 from datetime import datetime
-from .jar import references, log, file_handler
+from .jar import references, log, file_logger
 
+logger = logging.getLogger(__name__)
+logger.debug('Initialised module logger')
 
 def _organize_sess_dataframe(vardf):
     """ Takes input dataframe and tidies it up.
@@ -598,7 +600,7 @@ class session():
     #     logger = logging.getLogger('pbjam')  # <--- logs everything under pbjam
     #     fpath = os.path.join(self.path, 'session.log')
     #     self.handler = logging.FileHandler(fpath)
-    #     self.handler.setFormatter(_FMT)
+    #     self.handler.setFormatter(HANDLER_FMT)
     #     logger.addHandler(self.handler)
     
     # def remove_file_handler(self)
@@ -645,7 +647,7 @@ class session():
             science results!               
         """
         # self.add_file_handler()  # <--- conder changing this to a "with" statement for safe closing
-        with file_handler(self.path):
+        with file_logger(self.path):
             self.pb_model_type = model_type
 
             for i, st in enumerate(self.stars):

--- a/pbjam/session.py
+++ b/pbjam/session.py
@@ -49,10 +49,10 @@ import lightkurve as lk
 import numpy as np
 import astropy.units as units
 import pandas as pd
-import os, pickle, warnings
+import os, pickle, warnings, logging
 from .star import star, _format_name
 from datetime import datetime
-from .jar import references, log, file_logger
+from .jar import references, log, file_logging
 
 logger = logging.getLogger(__name__)
 logger.debug('Initialised module logger')
@@ -647,7 +647,7 @@ class session():
             science results!               
         """
         # self.add_file_handler()  # <--- conder changing this to a "with" statement for safe closing
-        with file_logger(self.path):
+        with file_logging(self.path):
             self.pb_model_type = model_type
 
             for i, st in enumerate(self.stars):

--- a/pbjam/session.py
+++ b/pbjam/session.py
@@ -647,7 +647,7 @@ class session():
             science results!               
         """
         # self.add_file_handler()  # <--- conder changing this to a "with" statement for safe closing
-        with file_logging(self.path):
+        with file_logging(os.path.join(self.path, 'session.log')):
             self.pb_model_type = model_type
 
             for i, st in enumerate(self.stars):

--- a/pbjam/star.py
+++ b/pbjam/star.py
@@ -420,7 +420,7 @@ class star(plotting):
             science results!    
         """
         # self.add_file_handler()
-        with file_logging(self.path):
+        with file_logging(os.path.join(self.path, 'star.log')):
             self.run_kde(bw_fac=bw_fac, make_plots=make_plots, store_chains=store_chains)
 
             self.run_asy_peakbag(norders=norders, make_plots=make_plots,

--- a/pbjam/star.py
+++ b/pbjam/star.py
@@ -30,6 +30,7 @@ import astropy.units as units
 import logging
 
 _logger = logging.getLogger(__name__)  # For module-level logging
+_logger.debug('Initialized module logger.')
 
 class star(plotting):
     """ Class for each star to be peakbagged
@@ -87,7 +88,7 @@ class star(plotting):
         self.ID = ID
 
         self._logger = logging.getLogger('.'.join([__name__, self.__class__.__name__]))
-        self._logger.info(f"Initialising star with ID {self.ID}.")
+        self._logger.debug('Initialized class logger.')
 
         if numax[0] < 25:
             warnings.warn('The input numax is less than 25. The prior is not well defined here, so be careful with the result.')
@@ -115,7 +116,8 @@ class star(plotting):
             self.prior_file = get_priorpath()
         else:
             self.prior_file = prior_file
-            
+
+        self._logger.info(f"Initialized star with ID {self.ID}.")
 
     def _checkTeffBpRp(self, teff, bp_rp):
         """ Set the Teff and/or bp_rp values
@@ -448,12 +450,12 @@ def _querySimbad(ID):
         Gaia DR2 source ID. Returns None if no Gaia ID is found.   
     """
     
-    print('Querying Simbad for Gaia ID')
+    _logger.debug('Querying Simbad for Gaia ID.')
 
     try:
         job = Simbad.query_objectids(ID)
     except:
-        print(f'Unable to resolve {ID} with Simbad')
+        _logger.debug(f'Unable to resolve {ID} with Simbad.')
         return None
     
     for line in job['ID']:
@@ -487,7 +489,7 @@ def _queryTIC(ID, radius = 20):
         Gaia bp-rp value from the TIC.   
     """
     
-    print('Querying TIC for Gaia bp-rp values.')
+    _logger.debug('Querying TIC for Gaia bp-rp values.')
     job = Catalogs.query_object(objectname=ID, catalog='TIC', objType='STAR', 
                                 radius = radius*units.arcsec)
 
@@ -518,7 +520,7 @@ def _queryMAST(ID):
     
     """
 
-    print(f'Querying MAST for the {ID} coordinates.')
+    _logger.debug(f'Querying MAST for the {ID} coordinates.')
     mastobs = AsqMastObsCl()
     try:            
         return mastobs.resolve_object(objectname = ID)
@@ -550,7 +552,7 @@ def _queryGaia(ID=None,coords=None, radius = 20):
         Gaia bp-rp value of the requested target from the Gaia archive.  
     """
     
-    print('Querying Gaia archive for bp-rp values.')
+    _logger.debug('Querying Gaia archive for bp-rp values.')
     
     from astroquery.gaia import Gaia
 
@@ -559,6 +561,7 @@ def _queryGaia(ID=None,coords=None, radius = 20):
         try:
             job = Gaia.launch_job(adql_query).get_results()
         except:
+            _logger.debug(f'Unable to query Gaia archive using ID={ID}.')
             return None
         return float(job['bp_rp'][0])
     
@@ -570,6 +573,7 @@ def _queryGaia(ID=None,coords=None, radius = 20):
         try:
             job = Gaia.launch_job(adql_query).get_results()
         except:
+            _logger.debug('Unable to query Gaia archive using coords={coords}.')
             return None
         return float(job['bp_rp'][0])
     else:
@@ -659,7 +663,8 @@ def get_bp_rp(ID):
                 coords = _queryMAST(ID)
                 bp_rp = _queryGaia(coords=coords)
             except:
-                print(f'Unable to retrieve a bp_rp value for {ID}.')
+                # Note that _logger.exception gives the full Traceback
+                _logger.exception(f'Unable to retrieve a bp_rp value for {ID}.')
                 bp_rp = np.nan
 
     return bp_rp

--- a/pbjam/star.py
+++ b/pbjam/star.py
@@ -28,7 +28,7 @@ from astroquery.simbad import Simbad
 import astropy.units as units
 
 import logging
-from .jar import log, file_logger
+from .jar import log, file_logging
 
 logger = logging.getLogger(__name__)  # For module-level logging
 logger.debug('Initialized module logger.')
@@ -420,7 +420,7 @@ class star(plotting):
             science results!    
         """
         # self.add_file_handler()
-        with file_logger(self.path):
+        with file_logging(self.path):
             self.run_kde(bw_fac=bw_fac, make_plots=make_plots, store_chains=store_chains)
 
             self.run_asy_peakbag(norders=norders, make_plots=make_plots,

--- a/pbjam/star.py
+++ b/pbjam/star.py
@@ -27,6 +27,9 @@ from astroquery.mast import Catalogs
 from astroquery.simbad import Simbad
 import astropy.units as units
 
+import logging
+
+_logger = logging.getLogger(__name__)  # For module-level logging
 
 class star(plotting):
     """ Class for each star to be peakbagged
@@ -82,6 +85,9 @@ class star(plotting):
                  path=None, prior_file=None):
 
         self.ID = ID
+
+        self._logger = logging.getLogger('.'.join([__name__, self.__class__.__name__]))
+        self._logger.info(f"Initialising star with ID {self.ID}.")
 
         if numax[0] < 25:
             warnings.warn('The input numax is less than 25. The prior is not well defined here, so be careful with the result.')


### PR DESCRIPTION
# WIP: Implement logging

Relates to Issue #175. Despite a lot of commits and information below, this PR is relatively straightforward. I am happy to discuss it over Zoom or similar!

- [x] Configures a base package `logger`
- [x] Adds a `@log` decorator for logging entering and exiting functions
    - [ ] Add `@log(logger)` decorator to all functions where useful
    - [ ] log more function information upon entering and exiting, thoughts welcome?
- [x] Adds a `file_logging` context manager
- [ ] Add logger warnings to regular warnings
- [ ] Log exception tracebacks
- [ ] Add info and debug logs everywhere!

## Logger

Following best-practices and suggestions in the Python docs, I add a `logger` to each module which takes the name of the module (`__name__`). The base logger for the package is called `'pbjam'` and is configured in the package `__init__.py`. All module loggers inherit from this, as is the beauty of logging! 

The base logger has one console stream at level `'INFO'` and above, to which all inherited loggers also stream. It is worth noting that `pbjam` is a package and not an application or script, so adding a console stream handler like this goes against the Python docs (see [here](https://docs.python.org/3/howto/logging.html#configuring-logging-for-a-library)). I would be perfectly happy not having console logging, but still having file logging when calling `session` and `star` as implemented below. I also think that this is most useful to the user and is when logging is most useful. If we really need something to output to the console then `print` is still perfectly fine. Happy to discuss this over Zoom or in the comments!

## Log decorator

The `@log` decorator can be added to any function in the `pbjam` modules by importing `from .jar import log`. Then, simply add the decorator to your function like so,

```python
import logging
from .jar import log

logger = logging.getLogger(__name__)

@log(logger)  # <--- logger is defined at the top of each module
def example_function():
    ...
```

This wraps the function by logging entering and exiting it - this is done by the functions `_entering_function` and `_exiting_function` in `jar.py`.

## File logging

For file logging, I had to consider that a `session` will run multiple instances of `star` and simply adding a logger handler each time one is initialised would continue sending logs to each previous star's log file. Also, the user can create many instances of `star` whenever they like, which could lead to unexpected results. Instead, I created a context manager which closes the file handler for each star after use. Note, this is not for the end-user, but just helps us implement file logging easily within PBjam routines. I put these in the `session` and `star` `__call__` functions, e.g. in `star`,

```python
    def __call__(self, bw_fac=1.0, norders=8, model_type='simple', tune=1500,
                 nthreads=1, make_plots=True, store_chains=False, 
                 asy_sampling='emcee', developer_mode=False):
        """
        ...
        """
        with file_logging(os.path.join(self.path, 'star.log')):
            self.run_kde(bw_fac=bw_fac, make_plots=make_plots, store_chains=store_chains)

            self.run_asy_peakbag(norders=norders, make_plots=make_plots,
                                store_chains=store_chains, method=asy_sampling,
                                developer_mode=developer_mode)

           ...
```

Everything that goes on under the `with` is then logged to `'star.log'` under the star's path. For `session` it is logged in `'session.log'` under the session's path.