### PR TITLE
Change assignment of custom lightcurve array to vardf DataFrame

### DIFF
--- a/pbjam/session.py
+++ b/pbjam/session.py
@@ -286,7 +286,8 @@ def _format_col(vardf, col, key):
     elif col.ndim == 2:
         x = np.array(col[0, :], dtype=float)
         y = np.array(col[1, :], dtype=float)
-        vardf[key] = [_arr_to_lk(x, y, vardf['ID'][0], key)]
+        vardf[key] = object()
+        vardf.at[0, key] = _arr_to_lk(x, y, vardf['ID'][0], key)
 
     # If dim = 3, it's a list of arrays or tuples
     elif col.ndim == 3:


### PR DESCRIPTION
Should fix "Datatype coercion is not allowed" error when using a custom lightcurve in Python 3.8+ without breaking 3.7- (see [issue #262](https://github.com/grd349/PBjam/issues/262)).