### PR TITLE
PEP440-compliant version number

### DIFF
--- a/pbjam/version.py
+++ b/pbjam/version.py
@@ -1,2 +1,2 @@
-__version__ = 'dev2.0.1'
+__version__ = '2.0.1.dev0'
 


### PR DESCRIPTION
setuptools 66 and greater enforces PEP440-style semantic versioning, where "dev" and other version modifiers come after the version number. Versions that do not conform will raise an InvalidVersion exception.