### PR TITLE
Quick pass with typos CLI tool

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,7 @@ PBjam is toolbox for analyzing the oscillation spectra of solar-like oscillators
 The mode identification works by fitting the asymptotic relation for p-modes to the l=2,0 pairs, which is followed by a applying selection of models for fitting the l=1 modes where each model is suitable for different stages of evolution.
 The process relies on of large set of previous observations of the model parameters, which are then used to construct a prior distribution to inform the sampling. The observations have been gathered from the Kepler, K2 and TESS missions, and expanding it to improve accuracy is an on-going process. 
 
-Modeling the modes, or 'peakbagging', is done using the a nested sampling or MCMC algorithm, where Lorentzian profiles are fit to each of the identified modes, with much fewer contraints than during the mode ID process. This allows for a more accurate model of the spectrum of frequencies than the heavily parameterized models like the asymptotic relations.
+Modeling the modes, or 'peakbagging', is done using the a nested sampling or MCMC algorithm, where Lorentzian profiles are fit to each of the identified modes, with much fewer constraints than during the mode ID process. This allows for a more accurate model of the spectrum of frequencies than the heavily parameterized models like the asymptotic relations.
 
 To get started with PBjam please see the docs at `pbjam.readthedocs.io <http://pbjam.readthedocs.io/>`_.
 

--- a/pbjam/DR.py
+++ b/pbjam/DR.py
@@ -25,7 +25,7 @@ class PCA():
         fName : str
             Full pathname of the csv file containing the prior sample
         nsamples : int
-            Number of neightbors to use.
+            Number of neighbors to use.
         weights : object, optional
             Array corresponding to N or callable function to get a list of 
             weights to apply to the data sample, by default None
@@ -170,7 +170,7 @@ class PCA():
         Returns
         -------
         pandas dataframe
-            Subset of pdata that contains only the N nearest neightbors.
+            Subset of pdata that contains only the N nearest neighbors.
         """
 
         limits = {'numax': 0.2,

--- a/pbjam/IO.py
+++ b/pbjam/IO.py
@@ -25,7 +25,7 @@ class psd():
 
     Notes
     -----
-    The Cython implemenation is very slow for time series longer than about 1 month 
+    The Cython implementation is very slow for time series longer than about 1 month 
     (array size of 1e5). The Fast implementation is similar to the an FFT, but at a 
     very slight loss of accuracy. There appears to be a slight increasing slope with 
     frequency toward the Nyquist frequency.
@@ -447,7 +447,7 @@ class timeSeries():
     def cleanLC(self, lc, outlierRejection):
         """ Perform Lightkurve operations on object.
 
-        Performes basic cleaning of a light curve, removing nans, outliers,
+        Performs basic cleaning of a light curve, removing nans, outliers,
         median filtering etc.
 
         Parameters

--- a/pbjam/core.py
+++ b/pbjam/core.py
@@ -89,7 +89,7 @@ class session():
 
     The observational constraints, such numax, dnu, teff, bp_rp, must be provided 
     through keyword entries in a dictionary, which is then passed via the obs 
-    argument when initalizing the session class.
+    argument when initializing the session class.
         
     Unless you provide the time series or spectrum, PBjam will download it. In
     which case it will do some rudimentary reduction, like removing outliers,
@@ -288,7 +288,7 @@ class star(plotting):
 
     The observational constraints, such numax, dnu, teff, bp_rp, must be provided 
     through keyword entries in a dictionary, which is then passed via the obs 
-    argument when initalizing the session class.
+    argument when initializing the session class.
         
     The star class only accepts a power density spectrum in the form of a list of
     frequency bins 'f' and power density 's'.

--- a/pbjam/jar.py
+++ b/pbjam/jar.py
@@ -119,7 +119,7 @@ class generalModelFuncs():
     def chi_sqr(self, mod):
         """ Chi^2 2 dof likelihood
 
-        Evaulates the likelihood of observing the data given the model.
+        Evaluates the likelihood of observing the data given the model.
 
         Parameters
         ----------

--- a/pbjam/l1models.py
+++ b/pbjam/l1models.py
@@ -160,7 +160,7 @@ class commonFuncs(jar.generalModelFuncs):
         freq_lims = (min(self.obs['nu0_p']) - fac*self.obs['dnu'][0],  
                      max(self.obs['nu0_p']) + fac*self.obs['dnu'][0])
         
-        # Start with an exagerated number of g-modes.
+        # Start with an exaggerated number of g-modes.
         init_n_g = jnp.arange(10000)[::-1] + 1
                 
         nu_g = self.asymptotic_nu_g(init_n_g, DPi1, eps_g)

--- a/pbjam/l20models.py
+++ b/pbjam/l20models.py
@@ -297,7 +297,7 @@ class Asyl20model(samplers.DynestySampling, jar.generalModelFuncs):
     def _get_n_p_max(self, dnu, numax, eps):
         """Compute radial order at numax.
     
-        Compute the radial order at numax, which in this implimentation of the
+        Compute the radial order at numax, which in this implementation of the
         asymptotic relation is not necessarily integer.
     
         Parameters

--- a/pbjam/peakbagging.py
+++ b/pbjam/peakbagging.py
@@ -1,6 +1,6 @@
 """
 The peakbagging module contains the classes used for the peakbag stage of PBjam. The 
-main class to interacte with is the peakbag class, which will handle potential slicing
+main class to interact with is the peakbag class, which will handle potential slicing
 of the spectrum or not and combine results for each case.
 """
 
@@ -59,7 +59,7 @@ class peakbag(plotting):
         case it's estimated from the provided `ell` and `freq` arrays.
     freqLimits : list, optional
         Frequency limits for the peakbagging. Default is an empty list, in which case the 
-        lowest and heighest radial mode frequencies -/+ 1 radial order are used to set the limits.
+        lowest and highest radial mode frequencies -/+ 1 radial order are used to set the limits.
     rotAsym : array-like, optional
         Rotational asymmetry parameters. Default is None.
     RV : array-like, optional
@@ -1101,7 +1101,7 @@ class basePeakbag(plotting):
             self.priors['shot'] = dist.normal(loc=0., scale=0.01)
 
         if not all([key in self.labels for key in self.priors.keys()]):
-            raise ValueError('Length of labels doesnt match lenght of priors.')
+            raise ValueError('Length of labels doesnt match length of priors.')
      
     def setLabels(self):
         """
@@ -1143,7 +1143,7 @@ class basePeakbag(plotting):
     def chi_sqr(self, mod):
         """ Chi^2 2 dof likelihood
 
-        Evaulates the likelihood of observing the data given the model.
+        Evaluates the likelihood of observing the data given the model.
 
         Parameters
         ----------
@@ -1164,7 +1164,7 @@ class basePeakbag(plotting):
                  'height' : {'info': 'mode height list'         , 'log10': True},
                  'width'  : {'info': 'mode width list'          , 'log10': True},
                  'nurot_e': {'info': 'envelope rotation rate'   , 'log10': False},
-                 'nurot_c': {'info': 'core otation rate'        , 'log10': False}, 
+                 'nurot_c': {'info': 'core rotation rate'       , 'log10': False}, 
                  'inc'    : {'info': 'stellar inclination axis' , 'log10': False},
                  'shot'   : {'info': 'Shot noise level'         , 'log10': True }}
    

--- a/pbjam/plotting.py
+++ b/pbjam/plotting.py
@@ -1390,7 +1390,7 @@ class plotting():
 
 
     # def _fill_diag(self, axes, vals, vals_err, idxs):
-    #     """ Overplot diagnoal values along a corner plot diagonal.
+    #     """ Overplot diagonal values along a corner plot diagonal.
         
     #     Plots a set of specified values over the 1D histograms in the diagonal 
     #     frames of a corner plot.

--- a/pbjam/samplers.py
+++ b/pbjam/samplers.py
@@ -363,7 +363,7 @@ class EmceeSampling():
 
         while stepsTaken < stepsNeeded:
 
-            # ensures no memory isues
+            # ensures no memory issues
             if sampler:
                 sampler.reset()
 
@@ -549,7 +549,7 @@ class EmceeSampling():
         
         tau = emcee.autocorr.integrated_time(ctrlChain, tol=0)
 
-        # ensures no memory isues
+        # ensures no memory issues
         if burnSampler:
             burnSampler.reset()
 
@@ -567,7 +567,7 @@ class EmceeSampling():
 
         self.ctrlChain = ctrlChain
 
-        # ensures no memory isues
+        # ensures no memory issues
         if postSampler:
             postSampler.reset()
 
@@ -595,7 +595,7 @@ class DynestySampling():
         Parameters
         ----------
         u : jax device array
-            Set of pionts distributed randomly in the unit hypercube.
+            Set of points distributed randomly in the unit hypercube.
 
         Returns
         -------

--- a/pbjam/validation.py
+++ b/pbjam/validation.py
@@ -55,7 +55,7 @@ class validate():
 
         Computes the p-value for the JS distance by generating a null-distribution of JS values.
         This is produced by drawing N sets of samples of size equal to the set of posterior samples
-        and computing the JS distane for random combinations of these sets. The p-value is then the 
+        and computing the JS distance for random combinations of these sets. The p-value is then the 
         fraction of N where the null-JS values are above the JS value of the posterior sample.
 
         The significance of a result is determined by comparing the p-value to a threshold.


### PR DESCRIPTION
Just a quick run through with a CLI tool called [typos](https://github.com/crate-ci/typos), which some of us are finding useful for picking up typos in e.g. docstrings, variable names, etc.